### PR TITLE
Add search support for multiple wildcards

### DIFF
--- a/src/wfsearch.c
+++ b/src/wfsearch.c
@@ -462,6 +462,8 @@ FillSearchLB(HWND hwndLB, LPWSTR szSearchFileSpec, BOOL bRecurse, BOOL bIncludeS
    INT iRet;
    WCHAR szFileSpec[MAXPATHLEN+1];
    WCHAR szPathName[MAXPATHLEN+1];
+   LPWCH lpszCurrentFileSpecStart;
+   LPWCH lpszCurrentFileSpecEnd;
    LPXDTALINK lpStart = NULL;
 
    //
@@ -473,21 +475,41 @@ FillSearchLB(HWND hwndLB, LPWSTR szSearchFileSpec, BOOL bRecurse, BOOL bIncludeS
    StripPath(szFileSpec);
    StripFilespec(szPathName);
 
-   FixUpFileSpec(szFileSpec);
-
+   lpszCurrentFileSpecEnd = szFileSpec;
+   
    maxExt = 0;
 
    iDirsRead = 1;
    dwLastUpdateTime = 0;
+   iRet = 0;
 
-   iRet = SearchList(hwndLB,
-                     szPathName,
-                     szFileSpec,
-                     bRecurse,
-	                 bIncludeSubdirs,
-                     &lpStart,
-                     0,
-                     TRUE);
+   //
+   // This loop runs for each subspec in the search string
+   //
+   while (*lpszCurrentFileSpecEnd) {
+	  lpszCurrentFileSpecStart = lpszCurrentFileSpecEnd;
+
+	  // Find the next separator or the end of the string
+	  while ((*lpszCurrentFileSpecEnd) && (*lpszCurrentFileSpecEnd) != ';')
+		 lpszCurrentFileSpecEnd++;
+	  // If a separator is reached, add the string terminator and move the
+	  // end after the terminator for the next cycle
+	  if (*lpszCurrentFileSpecEnd == ';') {
+		  *lpszCurrentFileSpecEnd = 0;
+		  lpszCurrentFileSpecEnd++;
+	  }
+
+	  FixUpFileSpec(lpszCurrentFileSpecStart);
+
+	  iRet += SearchList(hwndLB,
+		  szPathName,
+		  lpszCurrentFileSpecStart,
+		  bRecurse,
+		  bIncludeSubdirs,
+		  &lpStart,
+		  0,
+		  TRUE);
+   }
 
    //
    // Only SetSel if none set already


### PR DESCRIPTION
This adds support in the Search command for searching multiple wildcards separated by a semicolon (e.g. *.c;*.h).

Example: https://i.imgur.com/vi7BI7B.png