### PR TITLE
Fix stack buffer overflow in IDM_STARTCMDSHELL

### DIFF
--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -961,7 +961,7 @@ AppCommandProc(register DWORD id)
 			   }
 			   lstrcat(szToRun, TEXT("\\ConEmu\\ConEmu64.exe"));
 			   if (PathFileExists(szToRun)) {
-				   wnsprintf(szParams, MAXPATHLEN + 20, TEXT(" -Single -Dir \"%s\""), szDir);
+				   wnsprintf(szParams, sizeof(szParams) / sizeof(szParams[0]), TEXT(" -Single -Dir \"%s\""), szDir);
 				   bUseCmd = FALSE;
 			   }
 		   }

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -944,7 +944,7 @@ AppCommandProc(register DWORD id)
 		   DWORD cchEnv;
 		   TCHAR szToRun[MAXPATHLEN];
 		   LPTSTR szDir;
-		   TCHAR szParams[MAXPATHLEN];
+		   TCHAR szParams[MAXPATHLEN + 20];
 
 			szDir = GetSelection(1|4|16, &bDir);
 			if (!bDir)
@@ -961,7 +961,7 @@ AppCommandProc(register DWORD id)
 			   }
 			   lstrcat(szToRun, TEXT("\\ConEmu\\ConEmu64.exe"));
 			   if (PathFileExists(szToRun)) {
-				   wsprintf(szParams, TEXT(" -Single -Dir \"%s\""), szDir);
+				   wnsprintf(szParams, MAXPATHLEN + 20, TEXT(" -Single -Dir \"%s\""), szDir);
 				   bUseCmd = FALSE;
 			   }
 		   }


### PR DESCRIPTION
The buffer `szParams` has the same length as max path length. When you copy the format string ` -Single -Dir "<szDir inserted here>"`, it can overflow `szParams` by 4 bytes if `szDir` has the maximum length (247 bytes). This bug isn't exploitable, but it crashes winfile if I open the cmd shell with a long directory path.

This PR fixes it by increasing the length of `szParams`, and use `wnsprintf`.