### PR TITLE
When cold starting on Win10 with multi monitors, starts basically invisible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,6 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# Visual Studio temp project files
+*.vcxproj

--- a/.gitignore
+++ b/.gitignore
@@ -286,6 +286,3 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
-
-# Visual Studio temp project files
-*.vcxproj

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -1225,7 +1225,6 @@ JAPANEND
    {
       // window off virtual screen or initial case; put in main work area on primary screen
 	   SystemParametersInfo(SPI_GETWORKAREA, 0, (PVOID)&rcT, 0);
-	   rcT.right = rcT.bottom = (LONG)CW_USEDEFAULT;
        win.rc = rcT;
    }
 


### PR DESCRIPTION
I found on two different Win10 machines with multi-mon, the first time I ran winfile.exe the window was basically just the title bar (zero height client area) and infinitely wide (actually 0x80000000)).

This one line I removed is the cause and I can't see why it would be needed. SystemParametersInfo(SPI_GETWORKAREA) returns the correct RECT.

Did not test on any version of Windows other than Win10...


