### PR TITLE
Add Bash Shell support (partially fixes #44)

### DIFF
--- a/src/res.rc
+++ b/src/res.rc
@@ -58,6 +58,7 @@ BEGIN
 	"^x",       IDM_CUTTOCLIPBOARD, NOINVERT
 	"^c",       IDM_COPYTOCLIPBOARD, NOINVERT
 	"^v",       IDM_PASTE, NOINVERT
+	"^b",       IDM_STARTBASHSHELL, NOINVERT
 	"^k",       IDM_STARTCMDSHELL, NOINVERT
 	"^p",       IDM_STARTPOWERSHELL, NOINVERT
 	"^g",       IDM_GOTODIR, NOINVERT
@@ -93,6 +94,7 @@ BEGIN
     MENUITEM    "Cr&eate Directory...", IDM_MAKEDIR
     MENUITEM    "Searc&h...\tCtrl+F",       IDM_SEARCH
     MENUITEM    "Select &Files...", IDM_SELECT
+	MENUITEM    "Start Bash Shell...", IDM_STARTBASHSHELL
 	MENUITEM    "Start Cmd Shel&l...", IDM_STARTCMDSHELL
     MENUITEM    "Start Po&werShell...", IDM_STARTPOWERSHELL
 	MENUITEM    "&Goto Directory...\tCtrl+G", IDM_GOTODIR
@@ -196,6 +198,7 @@ BEGIN
     MENUITEM    "Re&name...\tF2",   IDM_RENAME
     MENUITEM    "Proper&ties...\tAlt+Enter",IDM_ATTRIBS
     MENUITEM    "&Run...",          IDM_RUN
+    MENUITEM    "Start Bash Shell...", IDM_STARTBASHSHELL
 	MENUITEM    "Start Cmd She&ll...", IDM_STARTCMDSHELL
 	MENUITEM    "Start Po&werShell...", IDM_STARTPOWERSHELL
 	MENUITEM    "&Goto Directory...", IDM_GOTODIR

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -856,26 +856,23 @@ BOOL GetBashExePath(LPTSTR szBashPath, UINT bufSize)
 {
 	const TCHAR szBashFilename[] = TEXT("bash.exe");
 	UINT len;
-	BOOL isWow64;
-#ifdef _WIN64
+
 	len = GetSystemDirectory(szBashPath, bufSize);
 	if ((len != 0) && (len + COUNTOF(szBashFilename) + 1 < bufSize) && PathAppend(szBashPath, TEXT("bash.exe")))
 	{
+		if (PathFileExists(szBashPath))
+			return TRUE;
+	}
+
+	// If we are running 32 bit Winfile on 64 bit Windows, System32 folder is redirected to SysWow64, which
+	// doesn't include bash.exe. So we also need to check Sysnative folder, which always maps to System32 folder.
+	len = ExpandEnvironmentStrings(TEXT("%SystemRoot%\\Sysnative\\bash.exe"), szBashPath, bufSize);
+	if (len != 0 && len <= bufSize)
+	{
 		return PathFileExists(szBashPath);
 	}
+
 	return FALSE;
-#else
-	/* Bash is not available on 32-bit Windows */
-	if (IsWow64Process(GetCurrentProcess(), &isWow64) && isWow64)
-	{
-		len = ExpandEnvironmentStrings(TEXT("%SystemRoot%\\Sysnative\\bash.exe"), szBashPath, bufSize);
-		if (len != 0 && len <= bufSize)
-		{
-			return PathFileExists(szBashPath);
-		}
-	}
-	return FALSE;
-#endif
 }
 /*--------------------------------------------------------------------------*/
 /*                                                                          */

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -918,6 +918,7 @@ BOOL  RectTreeItem(HWND hwndLB, register INT iItem, BOOL bFocusOn);
 #define IDM_HISTORYBACK     126
 #define IDM_HISTORYFWD      127
 #define IDM_STARTPOWERSHELL 128
+#define IDM_STARTBASHSHELL  129
 
 // This IDM_ is reserved for IDH_GROUP_ATTRIBS
 #define IDM_GROUP_ATTRIBS   199


### PR DESCRIPTION
This PR adds a "Start Bash Shell" to menu, which opens Bash on Windows, if it's installed.

While I totally agree with the comments in #44 that it is better to make this configurable, I don't have enough Windows GUI knowledge to write a configuration dialog. So far I only implemented a menu item "Start Bash Shell", which launches `bash.exe` if it exists. I want to share this code so that, if you want, you can develop on top of this PR.