### PR TITLE
Specify product name rather than rely on ntverp default

### DIFF
--- a/src/res.rc
+++ b/src/res.rc
@@ -688,6 +688,7 @@ END
 #define VER_FILEDESCRIPTION_STR     "File Manager"
 #define VER_INTERNALNAME_STR        "fileman\0"
 #define VER_ORIGINALFILENAME_STR     "WINFILE.EXE"
+#undef  VER_PRODUCTNAME_STR
 #define VER_PRODUCTNAME_STR         "File Manager"
 
 #include "common.ver"

--- a/src/res.rc
+++ b/src/res.rc
@@ -688,6 +688,7 @@ END
 #define VER_FILEDESCRIPTION_STR     "File Manager"
 #define VER_INTERNALNAME_STR        "fileman\0"
 #define VER_ORIGINALFILENAME_STR     "WINFILE.EXE"
+#define VER_PRODUCTNAME_STR         "File Manager"
 
 #include "common.ver"
 


### PR DESCRIPTION
Issue #53 calls out that the Winfile.exe product name is "Windows (R) Win7 DDK driver". This is because res.rc includes ntverp.h, and the version of ntverp.ver that is included with Windows 10 SDK defines the following:

`#define VER_PRODUCTNAME_STR         "Windows (R) Win 7 DDK driver"`

I addressed this by defining the product name as "File Manager", although another product name would be fine if something else is preferred. I also undefined VER_PRODUCTNAME_STR first to avoid resource compiler warning RC4005.
