### PR TITLE
Fix most compilation warnings at /W3 level

### DIFF
--- a/src/treectl.c
+++ b/src/treectl.c
@@ -2194,7 +2194,7 @@ TreeControlWndProc(
       WCHAR    ch;
       PDNODE    pNode;
       WCHAR rgchMatch[MAXPATHLEN];
-      INT cchMatch;
+      SIZE_T cchMatch;
 
       //
       // backslash means the root

--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -599,7 +599,7 @@ DirWndProc(
       UINT  cItems;
       LPWSTR szItem;
       WCHAR rgchMatch[MAXPATHLEN];
-      INT cchMatch;
+      SIZE_T cchMatch;
 
       if ((ch = LOWORD(wParam)) <= CHAR_SPACE || !GetWindowLongPtr(hwnd, GWL_HDTA))
          return(-1L);

--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -11,6 +11,7 @@
 
 #include "winfile.h"
 #include "lfn.h"
+#include "wfcopy.h"
 
 
 typedef enum {
@@ -1220,7 +1221,7 @@ DWORD DecodeReparsePoint(LPCWSTR szMyFile, LPCWSTR szChild, LPWSTR szDest, DWORD
 	StripFilespec(szFullPath);
 
 	if (szChild != NULL)
-		AppendToPath(szFullPath, szChild);
+		AppendToPath(szFullPath, (LPTSTR)szChild);
 
 	hFile = CreateFile(szFullPath, FILE_READ_EA, FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
 	if (hFile == INVALID_HANDLE_VALUE)

--- a/src/wfdrives.c
+++ b/src/wfdrives.c
@@ -15,6 +15,7 @@
 #include "lfn.h"
 #include "wfcopy.h"
 #include <commctrl.h>
+#include <shlobj.h>
 
 VOID RectDrive(INT nDrive, BOOL bFocusOn);
 VOID InvalidateDrive(DRIVEIND driveInd);

--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -103,7 +103,7 @@ vector<PDNODE> *FilterBySubtree(vector<PDNODE> * parents, vector<PDNODE> * child
 	vector<PDNODE> *results = new vector <PDNODE>();
 
 	// for each child, if parent in parents, return
-	for (int i = 0; i < children->size(); i++)
+	for (SIZE_T i = 0; i < children->size(); i++)
 	{
 		PDNODE child = children->at(i);
 		PDNODE parent = child->pParent;
@@ -490,7 +490,7 @@ VOID UpdateGotoList(HWND hDlg)
 	if (options == NULL)
 		return;
 		
-	for (int i = 0; i < 10 && i < options->size(); i++)
+	for (SIZE_T i = 0; i < 10 && i < options->size(); i++)
 	{
 		GetTreePath(options->at(i), szText);
 

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -16,6 +16,7 @@
 #include "wnetcaps.h"         // WNetGetCaps()
 
 #include <ole2.h>
+#include <shlobj.h>
 
 typedef VOID (APIENTRY *FNPENAPP)(WORD, BOOL);
 
@@ -950,7 +951,7 @@ JAPANEND
    // setup ini file location
    lstrcpy(szTheINIFile, szBaseINIFile);
    dwRetval = GetEnvironmentVariable(TEXT("APPDATA"), szBuffer, MAXPATHLEN);
-   if (dwRetval > 0 && dwRetval <= (MAXPATHLEN - lstrlen(szRoamINIPath) - 1 - lstrlen(szBaseINIFile) - 1)) {
+   if (dwRetval > 0 && dwRetval <= (DWORD)(MAXPATHLEN - lstrlen(szRoamINIPath) - 1 - lstrlen(szBaseINIFile) - 1)) {
 	   wsprintf(szTheINIFile, TEXT("%s%s"), szBuffer, szRoamINIPath);
 	   if (CreateDirectory(szTheINIFile, NULL) || GetLastError() == ERROR_ALREADY_EXISTS) {
 		   wsprintf(szTheINIFile, TEXT("%s%s\\%s"), szBuffer, szRoamINIPath, szBaseINIFile);


### PR DESCRIPTION
This patch fixes a number of simple warnings at /W3 level

They mostly boils down to theses simple (and not too severe) errors:

 - Storing unsinged numbers in singed variables, then comparing them
 back to unsigned numbers
 - Declaring for loop index variables as signed when testing it against
 unsigned values (eg: size of a container)
 - Using undeclared funcions in C. Compiler will fallback to thinking of
 them as extern function returning `int`. This *happens* to work because
 the linker will find the correct function later.

 **Note**: This path doesn't replace the usage of "unsafe" C standard function
 with their "safe" (generally postfixed _s) counterpart. I'm planning to
 submit a separate PR for that ;-)

Signed-off-by: Arthur Brainville (Ybalrid) <ybalrid@ybalrid.info>