### PR TITLE
Set the small icon for the MDI child on create window. This should di…

### DIFF
--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -472,6 +472,10 @@ CreateTreeWindow(
    SetWindowLongPtr(hwnd, GWL_SORT, dwNewSort);
    SetWindowLongPtr(hwnd, GWL_ATTRIBS, dwNewAttribs);
 
+   // Set the icon for the MDI Child
+   SendMessage(hwnd, WM_SETICON, ICON_SMALL, (LPARAM)hicoTreeDir);
+   
+
    return hwnd;
 }
 


### PR DESCRIPTION
…splay the TreeDir icon instead of the default windows icon.

Should resolve https://github.com/Microsoft/winfile/issues/52