### PR TITLE
Add WinFile-specific about dialog box

### DIFF
--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -2079,8 +2079,7 @@ ACPCallHelp:
        break;
 
     case IDM_ABOUT:
-       LoadString(hAppInstance, IDS_WINFILE, szTitle, COUNTOF(szTitle));
-       ShellAbout(hwndFrame, szTitle, NULL, NULL);
+       DialogBox(hAppInstance, (LPTSTR)MAKEINTRESOURCE(ABOUTDLG), hwndFrame, (DLGPROC)AboutDlgProc);
        break;
 
     case IDM_DRIVESMORE:

--- a/src/wfdlgs.h
+++ b/src/wfdlgs.h
@@ -61,6 +61,7 @@
 #define COMPRESSERRDLG          59  //  Compression Error Dialog
 
 #define GOTODIRDLG    60
+#define ABOUTDLG      61
 
 #define IDD_TEXT      -1
 #define IDD_TEXT1     100

--- a/src/wfdlgs3.c
+++ b/src/wfdlgs3.c
@@ -724,6 +724,28 @@ DoHelp:
   return TRUE;
 }
 
+/*--------------------------------------------------------------------------*/
+/*                                                                          */
+/*  AboutDlgProc() -  DialogProc callback function for ABOUTDLG             */
+/*                                                                          */
+/*--------------------------------------------------------------------------*/
+
+INT_PTR
+AboutDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (wMsg)
+    {
+    case WM_COMMAND:
+        switch (GET_WM_COMMAND_ID(wParam, lParam))
+        {
+        case IDOK:
+            EndDialog(hDlg, IDOK);
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
 VOID
 FormatDrive( IN PVOID ThreadParameter )
 {

--- a/src/wfdlgs3.c
+++ b/src/wfdlgs3.c
@@ -739,6 +739,7 @@ AboutDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
         switch (GET_WM_COMMAND_ID(wParam, lParam))
         {
         case IDOK:
+        case IDCANCEL:
             EndDialog(hDlg, IDOK);
             return TRUE;
         }

--- a/src/winfile.dlg
+++ b/src/winfile.dlg
@@ -807,3 +807,15 @@ BEGIN
     DEFPUSHBUTTON   "OK", IDOK, 418, 13, 40, 14, WS_GROUP
     PUSHBUTTON      "Cancel", IDCANCEL, 418, 30, 40, 14, WS_GROUP
 END
+
+ABOUTDLG DIALOG 13, 54, 250, 70
+STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "About File Manager"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    ICON            APPICON, -1, 6, 6, 32, 32
+    LTEXT           "Windows File Manager", -1, 36, 6, 200, 8
+    LTEXT           "Based on code from Microsoft Windows NT 4.0.", -1, 36, 18, 200, 8
+    LTEXT           "Maintained on GitHub at https://github.com/Microsoft/winfile", -1, 36, 30, 200, 8
+    DEFPUSHBUTTON   "OK", IDOK, 190, 50, 40, 14
+END

--- a/src/winfile.dlg
+++ b/src/winfile.dlg
@@ -808,14 +808,16 @@ BEGIN
     PUSHBUTTON      "Cancel", IDCANCEL, 418, 30, 40, 14, WS_GROUP
 END
 
-ABOUTDLG DIALOG 13, 54, 250, 70
+ABOUTDLG DIALOG 13, 54, 250, 100
 STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "About File Manager"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON            APPICON, -1, 6, 6, 32, 32
     LTEXT           "Windows File Manager", -1, 36, 6, 200, 8
-    LTEXT           "Based on code from Microsoft Windows NT 4.0.", -1, 36, 18, 200, 8
-    LTEXT           "Maintained on GitHub at https://github.com/Microsoft/winfile", -1, 36, 30, 200, 8
-    DEFPUSHBUTTON   "OK", IDOK, 190, 50, 40, 14
+    LTEXT           "Version 10.0", -1, 36, 18, 200, 8
+    LTEXT           "Copyright (c) Microsoft Corporation. All rights reserved.", -1, 36, 30, 200, 8
+    LTEXT           "Licensed under the MIT License.", -1, 36, 42, 200, 8
+    LTEXT           "https://github.com/Microsoft/winfile", -1, 36, 54, 200, 8
+    DEFPUSHBUTTON   "OK", IDOK, 190, 74, 40, 14
 END


### PR DESCRIPTION
As recommended in issue #40, an "About" dialog was added that is specific to the application. The dialog is simple; it could be expanded upon as needed. 

One note of interest: winfile.h already contained a function prototype named "AboutDlgProc", seemingly a dialog proc callback for an "About" dialog, but the code did not contain an implementation of that function. I suspect that the code previously had such a function and it was removed, or it was never implemented. Regardless, I left that prototype in place and implemented the DialogProc callback function using the same function name and signature.