### PR TITLE
Fixed broken link introduced with PR #95

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Please select the version which you would like to download.
 
 [Original_Plus](https://github.com/Microsoft/winfile/releases/tag/original_plus)
 
-To see more release binaries, including of older versions, [see the releases page](http://https://github.com/Microsoft/winfile/releases).
-
+To see more release binaries, including of older versions, [see the releases page](https://github.com/Microsoft/winfile/releases).
 
 
 ## History


### PR DESCRIPTION
This commit fixes an issue introduced in PR #95.

The link to the "Releases" page had a redundant https prefix, causing the link to be broken. The redundant prefer is removed and the link should work correctly.