### PR TITLE
App Version Updated to Version 1804

### DIFF
--- a/src/res.rc
+++ b/src/res.rc
@@ -700,10 +700,10 @@ END
 #define VER_PRODUCTNAME_STR         "File Manager"
 #define VER_LEGALCOPYRIGHT_STR      "Copyright (c) Microsoft Corporation. All rights reserved."
 
-#define VER_FILEVERSION             10,0,0,0
-#define VER_FILEVERSION_STR         "10.0.0.0\0"
-#define VER_PRODUCTVERSION          10,0,0,0
-#define VER_PRODUCTVERSION_STR      "10.0.0.0\0"
+#define VER_FILEVERSION             10,0,1804,0
+#define VER_FILEVERSION_STR         "10.0.1804.0\0"
+#define VER_PRODUCTVERSION          10,0,1804,0
+#define VER_PRODUCTVERSION_STR      "10.0.1804.0\0"
 
 #ifndef DEBUG
 #define VER_DEBUG                   0


### PR DESCRIPTION
The application version has been updated from version 10.0.0.0 to version 10.0.1804.0. I've not updated the major or minor version; so it's still version 10.0 as of now. The 1804 signifies that it is the April 2018 code.

![file manager version 1804](https://user-images.githubusercontent.com/5572377/38961836-6bb7bada-4338-11e8-9104-75b12566d199.png)

Since there is no automated versioning system implimented yet, this allows us to at least easily update the version without worrying about whether to increment the major or minor version.

Note: I originally wanted to go with something like 180418, (YYMMDD) to include the day. This way, whoever commits a code, they would just update the version number to reflect the date. Then it'd be super easy to tell which "build" one is runnign for troubleshooting reasons. But I went with just YYMM (1804) because we'd only need to increment the version at least once a month.

But I'm interested to hear what you think of how versioning should be done.