### PR TITLE
Don't return ERROR_INVALID_FUNCTION on x64 builds for enumerate errors (#135)

### DIFF
--- a/src/lfn.c
+++ b/src/lfn.c
@@ -140,7 +140,7 @@ WFFindNext(LPLFNDTA lpFind)
       }
 
 	  Wow64RevertWow64FsRedirection(oldValue);
-
+      lpFind->err = 0;
       return TRUE;
    }
 

--- a/src/lfn.c
+++ b/src/lfn.c
@@ -57,6 +57,12 @@ WFFindFirst(
 	   lpFind->hFindFile = FindFirstFile(lpName, &lpFind->fd);
    }
 
+   if (lpFind->hFindFile == INVALID_HANDLE_VALUE) {
+       lpFind->err = GetLastError();
+   } else {
+       lpFind->err = 0;
+   }
+
    // add in attr_* which we want to include in the match even though the caller didn't request them.
    dwAttrFilter |= ATTR_ARCHIVE | ATTR_READONLY | ATTR_NORMAL | ATTR_REPARSE_POINT |
 	   ATTR_TEMPORARY | ATTR_COMPRESSED | ATTR_NOT_INDEXED;
@@ -82,18 +88,12 @@ WFFindFirst(
       lpFind->dwAttrFilter = dwAttrFilter;
       if ((~dwAttrFilter & lpFind->fd.dwFileAttributes) == 0L ||
          WFFindNext(lpFind)) {
-
-         lpFind->err = 0;
-
          return(TRUE);
       } else {
-         lpFind->err = GetLastError();
-
          WFFindClose(lpFind);
          return(FALSE);
       }
    } else {
-      lpFind->err = GetLastError();
       return(FALSE);
    }
 }

--- a/src/lfn.c
+++ b/src/lfn.c
@@ -144,9 +144,9 @@ WFFindNext(LPLFNDTA lpFind)
       return TRUE;
    }
 
-   Wow64RevertWow64FsRedirection(oldValue);
-
    lpFind->err = GetLastError();
+
+   Wow64RevertWow64FsRedirection(oldValue);
    return(FALSE);
 }
 


### PR DESCRIPTION
Looks like WOW redirection on x64 causes LastError to be reset, and the directory enumerate code was expecting ERROR_ACCESS_DENIED not ERROR_INVALID_FUNCTION.  Note this is specific to x64.

~~(I'm not thrilled about how this works when FindFirstFile finds something that the filter wants to remove.  Previously LastError in this case seemed random, now it returns FALSE with LastError of zero.)~~

When filtering FindFirst will always call FindNext, and FindNext is the thing setting the error.  It also had the same WOW bug though.