### PR TITLE
Solving warning c6400

### DIFF
--- a/src/BagOValues.h
+++ b/src/BagOValues.h
@@ -89,7 +89,8 @@ namespace winfile {
 		using lock_unlock = internal::lock_unlock;
 	public:
 		typedef T value_type;
-		using storage_type = std::multimap< std::wstring, value_type >;
+		typedef std::wstring key_type;
+		using storage_type = std::multimap< key_type, value_type >;
 		using value_vector = std::vector< value_type >;
 	private:
 		mutable storage_type key_value_storage_{};
@@ -141,7 +142,7 @@ namespace winfile {
 		/// <summary>
 		/// add's by enforcing the value semantics
 		/// </summary>
-		void Add(std::wstring key, value_type value)
+		void Add(key_type key, value_type value)
 		{
 			lock_unlock padlock{};
 			internal::lowerize(key);
@@ -162,7 +163,7 @@ namespace winfile {
 		/// </summary>
 		value_vector
 			Retrieve(
-				const		std::wstring & query,
+				const		key_type & query,
 				bool		find_by_prefix = true,
 				/* currently we ignore maxResults */
 				unsigned	maxResults = ULONG_MAX
@@ -173,7 +174,7 @@ namespace winfile {
 			if (key_value_storage_.size() < 1)
 				return retval_;
 
-			internal::lowerize(const_cast<std::wstring &>(query));
+			internal::lowerize(const_cast<key_type &>(query));
 
 			if (true == find_by_prefix) {
 				retval_ = prefix_match_query(query);
@@ -193,7 +194,7 @@ namespace winfile {
 		value_vector
 			exact_match_query(
 				// must be lower case!
-				const	std::wstring & query
+				const	key_type & query
 			)
 		{
 			value_vector retvec{};
@@ -214,7 +215,7 @@ namespace winfile {
 		value_vector
 			prefix_match_query(
 				// must be lower case!
-				const	std::wstring & prefix_
+				const	key_type & prefix_
 			)
 		{
 			value_vector retvec{};

--- a/src/BagOValues.h
+++ b/src/BagOValues.h
@@ -1,118 +1,256 @@
 /********************************************************************
 
-   BagOValues.h
+BagOValues.h
 
-   Copyright (c) Microsoft Corporation. All rights reserved.
-   Licensed under the MIT License.
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
 
 ********************************************************************/
+#pragma once
+
+// avoid min/max macros 
+#define NOMINMAX
 
 #include <map>
 #include <vector>
 #include <algorithm>
+#include <cwctype>
+#include <atomic>
 
-#include "spinlock.h"
+#include "sysinfoapi.h"
 
-using namespace std;
+namespace winfile {
 
-template <class TValue>
-class BagOValues
-{
-	typedef pair<wstring, TValue> TPair;
-	typedef vector<TPair> TVector;
-	typedef typename TVector::const_iterator TItr;
+	using namespace std;
 
-	SpinLock m_spinlock;
-	TVector m_Values;
-	wstring m_lastStr;
-	TItr m_LastItr;
+	namespace internal {
 
-public:
-	BagOValues()
-	{
-	}
+		using namespace std;
 
-	// copies the value, but doesn't assume any memory management needs be done
-	void Add(wstring key, TValue value)
-	{
-		this->m_spinlock.Lock();
-		wstring lowered;
-		lowered.resize(key.size());
-		transform(std::begin(key), std::end(key), std::begin(lowered), ::tolower);
-		m_Values.emplace_back(make_pair(std::move(lowered), value));
+		struct lock_unlock final {
+			std::atomic_flag atom_flag_ = ATOMIC_FLAG_INIT;
 
-		m_lastStr.resize(0);	// clear this after new data added
-		this->m_spinlock.Unlock();
-	}
+			lock_unlock() { atom_flag_.test_and_set(); }
+			~lock_unlock() { atom_flag_.clear(); }
+		};
 
-	void Sort()
-	{
-		this->m_spinlock.Lock();
-		sort(m_Values.begin(), m_Values.end());
-		this->m_spinlock.Unlock();
-	}
+		template <typename T>
+		class guardian final {
+		public:
+				typedef T value_type;
+			value_type load() {
+				lock_unlock locker_;
+				return treasure_;
+			}
+			value_type store(value_type new_value) {
+				lock_unlock locker_;
+				return treasure_ = new_value;
+			}
+		private:
+			value_type treasure_{};
+		};
 
-	// Retrieve with fPrefix = true means return values for the tree at the point of the query matched; 
-	//      we must consume the whole query for anything to be returned
-	// fPrefix = false means that we only return values when an entire key matches and we match substrings of the query
-	//
-	// NOTE: returns a newly allocated vector; must delete it
-	vector<TValue> Retrieve(const wstring& query, bool fPrefix = true, unsigned maxResults = ULONG_MAX)
-	{
-		wstring lowered;
-		lowered.resize(query.size());
-		transform(std::cbegin(query), std::cend(query), std::begin(lowered), ::tolower);
-
-		vector<TValue> results;
-		TValue val = TValue();
-		TPair laspair = make_pair(lowered, val);
-
-		this->m_spinlock.Lock();
-
-		// if last saved string/iterator is a prefix of the new string, start there
-		TItr itr;
-		if (m_lastStr.size() != 0 && lowered.compare(0, m_lastStr.size(), m_lastStr) == 0)
-			itr = m_LastItr;
-		else
+		// return e.g. L"C:\windows\system32"
+		inline const std::wstring windir()
 		{
-			itr = lower_bound(m_Values.begin(), m_Values.end(), laspair, CompareFirst);
-
-			m_lastStr = lowered;
-			m_LastItr = itr;
+			lock_unlock padlock_;
+			static wchar_t  result_buf[BUFSIZ]{};
+			static auto retval = ::GetSystemDirectoryW(
+				result_buf,
+				BUFSIZ
+			);
+			_ASSERTE(retval);
+			return wstring{ result_buf };
 		}
 
-		for (; itr != m_Values.end(); itr++)
+		// what happens if there is no drive C: ?
+		// shoud we not ask for the system drive letter
+		// the first 3 chars that is, e.g. L"C:\\"
+		inline const std::wstring windrive()
 		{
-			const wstring& key = itr->first;
-			int cmp = key.compare(0, lowered.size(), lowered);
-			if (cmp == 0)
-			{
-				if (!fPrefix && key.size() != lowered.size())
-				{
-					// need exact match (not just prefix); skip
-					continue;
+			lock_unlock padlock_;
+			static wstring result = windir().substr(0, 3);
+			_ASSERTE(result.size() == 3);
+			return result;
+		}
+
+		inline void lowerize(wstring & key) {
+			transform(key.begin(), key.end(), key.begin(), std::towlower);
+		};
+
+		template<class InputIt1, class InputIt2>
+		bool equal_(InputIt1 first1, InputIt1 last1, InputIt2 first2)
+		{
+			for (; first1 != last1; ++first1, ++first2) {
+				if (!(*first1 == *first2)) {
+					return false;
 				}
-
-				if (results.size() >= maxResults)
-					break;
-
-				results.push_back(itr->second);
 			}
-			else if (cmp > 0)
-			{
-				// iterated past the strings which match on the prefix
-				break;
-			}
+			return true;
 		}
 
-		this->m_spinlock.Unlock();
-		return results;
+		inline  bool  is_prefix(
+			const std::wstring & lhs, const std::wstring & rhs
+		)
+		{
+			_ASSERTE(lhs.size() > 0);
+			_ASSERTE(rhs.size() > 0);
+
+			return equal_(
+				lhs.begin(),
+				lhs.begin() + std::min(lhs.size(), rhs.size()),
+				rhs.begin());
+		}
+
 	}
 
-private:
-	static bool CompareFirst(const TPair& a, const TPair& b)
+	template <typename T>
+	class BagOValues final
 	{
-		return a.first < b.first;
-	}
-};
+		using lock_unlock = internal::lock_unlock;
+	public:
+		typedef T value_type;
+		using storage_type = std::multimap< std::wstring, value_type >;
+		using value_vector = std::vector< value_type >;
+	private:
+		mutable storage_type key_value_storage_{};
+	public:
+		/*
+		the aim is to be able to use instances of this class as values
+		c++ compiler will generate all the things necessary
+		we will privide the "swap" method to be used for move semantics
+		*/
+		void swap(BagOValues & other_)	noexcept
+		{	// swap contents with other_
+			lock_unlock padlock{};
+			this->key_value_storage_ = other_.key_value_storage_;
+		}
+		
+		/// <summary>
+		/// clear the storage held
+		/// </summary>
+		void Clear() const {
+			lock_unlock padlock{};
+			key_value_storage_.clear();
+		}
 
+		/// <summary>
+		/// the argument of the callback is the 
+		/// storage_type::value_type
+		/// which in turn is pair 
+		/// wstring is the key, T is the value
+		/// </summary>
+		template< typename F>
+		const auto ForEach(F callback_) const noexcept {
+			lock_unlock padlock{};
+			return
+				std::for_each(
+					this->key_value_storage_.begin(),
+					this->key_value_storage_.end(),
+					callback_
+				);
+		}
+		
+		/// <summary>
+		/// is the storage held empty?
+		/// </summary>
+		const bool Empty() const noexcept {
+			lock_unlock padlock{};
+			return this->key_value_storage_.size() < 1;
+		}
+		
+		/// <summary>
+		/// add's by enforcing the value semantics
+		/// </summary>
+		void Add(std::wstring key, value_type value)
+		{
+			lock_unlock padlock{};
+			internal::lowerize(key);
+			key_value_storage_.emplace(key, value);
+		}
+
+		/// <summary>
+		/// std::multimap is already sorted
+		/// </summary>
+		void Sort() noexcept
+		{
+			// no op
+		}
+
+		/// <summary>
+		/// if find_by_prefix is false the exact key match should  be performed
+		/// if true all the prexies matching are going into the result
+		/// </summary>
+		value_vector
+			Retrieve(
+				const		std::wstring & query,
+				bool		find_by_prefix = true,
+				/* currently we ignore maxResults */
+				unsigned	maxResults = ULONG_MAX
+			)
+		{
+			lock_unlock padlock{};
+			value_vector retval_{};
+			if (key_value_storage_.size() < 1)
+				return retval_;
+
+			internal::lowerize(const_cast<std::wstring &>(query));
+
+			if (true == find_by_prefix) {
+				retval_ = prefix_match_query(query);
+			}
+
+			if (false == find_by_prefix) {
+				retval_ = exact_match_query(query);
+			}
+			return retval_;
+		}
+
+	private:
+		/* do not use as public in this form */
+		value_vector
+			exact_match_query(
+				// must be lower case!
+				const	std::wstring & query
+			)
+		{
+			value_vector retvec{};
+
+			auto range = key_value_storage_.equal_range(query);
+			if (range.first == key_value_storage_.end()) return retvec;
+
+			std::transform(
+				range.first,
+				range.second,
+				std::back_inserter(retvec),
+				[](typename storage_type::value_type element) { return element.second; }
+			);
+			return retvec;
+		}
+
+		/* do not use as public in this form */
+		value_vector
+			prefix_match_query(
+				// must be lower case!
+				const	std::wstring & prefix_
+			)
+		{
+			value_vector retvec{};
+			auto walker_ = key_value_storage_.upper_bound(prefix_);
+
+			while (walker_ != key_value_storage_.end())
+			{
+				// if prefix of the current key add its value to the result
+				if (internal::is_prefix(prefix_, walker_->first)) {
+					retvec.push_back(walker_->second);
+				}
+				// advance the iterator 
+				walker_++;
+			}
+
+			return retvec;
+		}
+
+	}; // eof BagOValues 
+
+} // winfile namespace

--- a/src/BagOValues.h
+++ b/src/BagOValues.h
@@ -10,6 +10,7 @@ Licensed under the MIT License.
 
 // avoid min/max macros 
 #define NOMINMAX
+// mutex is (much) lighter on cpu vs std::atomic_flag
 #define WINFILE_STD_MUTEX_USE 
 
 #include <map>
@@ -22,12 +23,15 @@ Licensed under the MIT License.
 #include <mutex>
 #endif
 
+// the WinFile namespace
 namespace winfile {
 
 	using namespace std;
 
+	// winfile internal mechanisms
+	// available to re-use
+	// elsewhere
 	namespace internal {
-
 
 #ifndef WINFILE_STD_MUTEX_USE 
 		struct lock_unlock final {
@@ -61,10 +65,17 @@ namespace winfile {
 			value_type treasure_{};
 		};
 
+		/// <summary>
+		/// argument is a reference 
+		/// and is "lowerized" in place
+		/// </summary>
 		inline void lowerize(wstring & key) {
 			transform(key.begin(), key.end(), key.begin(), std::towlower);
 		};
 
+		// std::equal has many overloads
+		// it is leass error prone to have here
+		// and use this one we exactly need
 		template<class InputIt1, class InputIt2>
 		bool equal_(InputIt1 first1, InputIt1 last1, InputIt2 first2)
 		{
@@ -78,6 +89,7 @@ namespace winfile {
 
 		/// <summary>
 		/// is Lhs prefix to Rhs
+		/// L must be shorter than R
 		/// </summary>
 		inline  bool  is_prefix(
 			const std::wstring & lhs, const std::wstring & rhs
@@ -212,6 +224,10 @@ namespace winfile {
 				const	key_type & query
 			)
 		{
+			/// <summary>
+			/// general question is why is vector of values returned?
+			/// vector of keys is lighter
+			/// </summary>
 			value_vector retvec{};
 
 			auto range = key_value_storage_.equal_range(query);
@@ -233,6 +249,10 @@ namespace winfile {
 				const	key_type & prefix_
 			)
 		{
+			/// <summary>
+			/// general question is why is vector of values returned?
+			/// vector of keys is lighter
+			/// </summary>
 			value_vector retvec{};
 			auto walker_ = key_value_storage_.upper_bound(prefix_);
 
@@ -248,7 +268,6 @@ namespace winfile {
 					break;
 				}
 			}
-
 			return retvec;
 		}
 

--- a/src/BagOValues.h
+++ b/src/BagOValues.h
@@ -17,8 +17,6 @@ Licensed under the MIT License.
 #include <cwctype>
 #include <atomic>
 
-#include "sysinfoapi.h"
-
 namespace winfile {
 
 	using namespace std;
@@ -49,30 +47,6 @@ namespace winfile {
 		private:
 			value_type treasure_{};
 		};
-
-		// return e.g. L"C:\windows\system32"
-		inline const std::wstring windir()
-		{
-			lock_unlock padlock_;
-			static wchar_t  result_buf[BUFSIZ]{};
-			static auto retval = ::GetSystemDirectoryW(
-				result_buf,
-				BUFSIZ
-			);
-			_ASSERTE(retval);
-			return wstring{ result_buf };
-		}
-
-		// what happens if there is no drive C: ?
-		// shoud we not ask for the system drive letter
-		// the first 3 chars that is, e.g. L"C:\\"
-		inline const std::wstring windrive()
-		{
-			lock_unlock padlock_;
-			static wstring result = windir().substr(0, 3);
-			_ASSERTE(result.size() == 3);
-			return result;
-		}
 
 		inline void lowerize(wstring & key) {
 			transform(key.begin(), key.end(), key.begin(), std::towlower);

--- a/src/BagOValues.h
+++ b/src/BagOValues.h
@@ -61,6 +61,9 @@ namespace winfile {
 			return true;
 		}
 
+		/// <summary>
+		/// is Lhs prefix to Rhs
+		/// </summary>
 		inline  bool  is_prefix(
 			const std::wstring & lhs, const std::wstring & rhs
 		)
@@ -68,9 +71,13 @@ namespace winfile {
 			_ASSERTE(lhs.size() > 0);
 			_ASSERTE(rhs.size() > 0);
 
+			// "predefined" can not be a prefix to "pre" 
+			// opposite is true
+			if (lhs.size() > rhs.size()) return false;
+
 			return equal_(
 				lhs.begin(),
-				lhs.begin() + std::min(lhs.size(), rhs.size()),
+				lhs.end(), 
 				rhs.begin());
 		}
 
@@ -151,7 +158,7 @@ namespace winfile {
 
 		/// <summary>
 		/// if find_by_prefix is false the exact key match should  be performed
-		/// if true all the prexies matching are going into the result
+		/// if true all the keys matching are going into the result
 		/// </summary>
 		value_vector
 			Retrieve(
@@ -170,6 +177,9 @@ namespace winfile {
 
 			if (true == find_by_prefix) {
 				retval_ = prefix_match_query(query);
+
+				if (retval_.size() < 1)
+					find_by_prefix = false;
 			}
 
 			if (false == find_by_prefix) {
@@ -215,9 +225,12 @@ namespace winfile {
 				// if prefix of the current key add its value to the result
 				if (internal::is_prefix(prefix_, walker_->first)) {
 					retvec.push_back(walker_->second);
+					// advance the iterator 
+					walker_++;
 				}
-				// advance the iterator 
-				walker_++;
+				else {
+					break;
+				}
 			}
 
 			return retvec;

--- a/src/BagOValues.h
+++ b/src/BagOValues.h
@@ -23,8 +23,6 @@ namespace winfile {
 
 	namespace internal {
 
-		using namespace std;
-
 		struct lock_unlock final {
 			std::atomic_flag atom_flag_ = ATOMIC_FLAG_INIT;
 

--- a/src/Winfile.vcxproj
+++ b/src/Winfile.vcxproj
@@ -222,6 +222,7 @@
     <ClInclude Include="wfmem.h" />
     <ClInclude Include="winexp.h" />
     <ClInclude Include="winfile.h" />
+    <ClInclude Include="winfile_internals.h" />
     <ClInclude Include="wnetcaps.h" />
   </ItemGroup>
   <ItemGroup>
@@ -276,6 +277,7 @@
     <ClCompile Include="wftree.c" />
     <ClCompile Include="wfutil.c" />
     <ClCompile Include="winfile.c" />
+    <ClCompile Include="winfile_internals.c" />
     <ClCompile Include="wnetcaps.c" />
   </ItemGroup>
   <ItemGroup>

--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -19,11 +19,15 @@ extern "C"
 #include "lfn.h"
 }
 
-void BuildDirectoryBagOValues(BagOValues<PDNODE> *pbov, LPTSTR szRoot, PDNODE pNode);
-void FreeDirectoryBagOValues(BagOValues<PDNODE> *pbov);
+// using BagOValues = winfile::BagOValues<PDNODE> ;
+
+using namespace std;
+
+void BuildDirectoryBagOValues(winfile::BagOValues<PDNODE> *pbov, LPTSTR szRoot, PDNODE pNode);
+void FreeDirectoryBagOValues(winfile::BagOValues<PDNODE> *pbov);
 
 DWORD g_driveScanEpoc;				// incremented when a refresh is requested; old bags are discarded; scans are aborted if epoc changes
-BagOValues<PDNODE> *g_pBagOCDrive;	// holds the values from the scan per g_driveScanEpoc
+winfile::BagOValues<PDNODE> *g_pBagOCDrive;	// holds the values from the scan per g_driveScanEpoc
 vector<PDNODE> *g_allNodes;			// holds the nodes we created to make freeing them simpler (e.g., because some are reused)
 
 // compare path starting at the root; returns:
@@ -279,20 +283,20 @@ vector<wstring> SplitIntoWords(LPCTSTR szText)
 	return words;
 }
 
-void FreeDirectoryBagOValues(BagOValues<PDNODE> *pbov, vector<PDNODE> *pNodes)
+void FreeDirectoryBagOValues(winfile::BagOValues<PDNODE> *pbov, vector<PDNODE> *pNodes)
 {
-	// free all PDNODE in BagOValues
+	// free all PDNODE in winfile::BagOValues
 	for (PDNODE p : *pNodes)
 	{
 		LocalFree(p);
 	}
 
-	// free that vector and the BagOValues itself
+	// free that vector and the winfile::BagOValues itself
 	delete pNodes;
 	delete pbov;
 }
 
-BOOL BuildDirectoryBagOValues(BagOValues<PDNODE> *pbov, vector<PDNODE> *pNodes, LPCTSTR szRoot, PDNODE pNodeParent, DWORD scanEpoc)
+BOOL BuildDirectoryBagOValues(winfile::BagOValues<PDNODE> *pbov, vector<PDNODE> *pNodes, LPCTSTR szRoot, PDNODE pNodeParent, DWORD scanEpoc)
 {
 	LFNDTA lfndta;
 	WCHAR szPath[MAXPATHLEN];
@@ -343,7 +347,7 @@ BOOL BuildDirectoryBagOValues(BagOValues<PDNODE> *pbov, vector<PDNODE> *pNodes, 
 			return FALSE;
 		}
 
-		// for all directories at this level, insert into BagOValues
+		// for all directories at this level, insert into winfile::BagOValues
 
 		if ((lfndta.fd.dwFileAttributes & ATTR_DIR) == 0 || ISDOTDIR(lfndta.fd.cFileName))
 		{
@@ -648,7 +652,7 @@ BuildDirectoryTreeBagOValues(PVOID pv)
 {
 	DWORD scanEpocNew = InterlockedIncrement(&g_driveScanEpoc);
 
-	BagOValues<PDNODE> *pBagNew = new BagOValues<PDNODE>();
+	winfile::BagOValues<PDNODE> *pBagNew = new winfile::BagOValues<PDNODE>();
 	vector<PDNODE> *pNodes = new vector<PDNODE>();
 
 	SendMessage(hwndStatus, SB_SETTEXT, 2, (LPARAM)TEXT("BUILDING GOTO CACHE"));
@@ -657,7 +661,7 @@ BuildDirectoryTreeBagOValues(PVOID pv)
 	{
 		pBagNew->Sort();
 
-		pBagNew = (BagOValues<PDNODE> *)InterlockedExchangePointer((PVOID *)&g_pBagOCDrive, pBagNew);
+		pBagNew = (winfile::BagOValues<PDNODE> *)InterlockedExchangePointer((PVOID *)&g_pBagOCDrive, pBagNew);
 		pNodes = (vector<PDNODE> *)InterlockedExchangePointer((PVOID *)&g_allNodes, pNodes);
 	}
 

--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -19,7 +19,11 @@ extern "C"
 #include "lfn.h"
 }
 
-// using BagOValues = winfile::BagOValues<PDNODE> ;
+// Explicitly instantiate what we use in here
+template class std::vector<PDNODE>;
+namespace winfile {
+	template class BagOValues<PDNODE>;
+}
 
 using namespace std;
 

--- a/src/winfile_internals.c
+++ b/src/winfile_internals.c
@@ -2,27 +2,44 @@
 2018-04-30	dbj@dbj.org		created
 */
 #include <windows.h>
-#include <ntddkbd.h>
+// #include <ntdef.h>
 #include "winfile_internals.h"
 
 /// <summary>
 /// non-linguistic byte level comparison of strings
-/// note: RtlCompare[Unicode]String is called from CompareString[Ex]
+/// note: RtlCompare[Unicode]String is now part of WDK and is thus
+/// not a feasible solution for legacy code
+/// Thus what seems as a cludge is to use CompareString in a locale invariant mode
+/// alernative is to develop a solution using strcmp() and friends ...
+/// So this is not a ordinal comparison but only for ASCI build of winfile
+/// which is if not non existent than very rare variant of winfile
 /// </summary>
-int winfile_exact_string_compareA(const char * str1, const char * str2, unsigned char CaseInSensitive) {
-	return RtlCompareString(
-		str1, str2, CaseInSensitive
-	);
+int winfile_ordinal_string_compareA(const char * str1, const char * str2, unsigned char ignore_case) {
+
+	return CompareStringA(
+		/* _In_ LCID    */ LOCALE_INVARIANT,
+		/* _In_ DWORD   */ ignore_case == 1 ? LINGUISTIC_IGNORECASE : NORM_LINGUISTIC_CASING,
+		/* _In_ LPCTSTR */ str1,
+		/* _In_ int     */ -1,
+		/* _In_ LPCTSTR */ str2,
+		/* _In_ int     */ -1);
 }
 
-int winfile_exact_string_compareW(const wchar_t * str1, const wchar_t * str2, unsigned char CaseInSensitive) {
-	return RtlCompareUnicodeString(
-		str1, str2, CaseInSensitive
+/// <summary>
+/// CompareStringOrdinal simply does not exist for asci strings
+/// which is telling, in the context of one will never
+/// need it, because one will not build non unicode apps 
+/// from XP onwards that is
+/// </summary>
+int winfile_ordinal_string_compareW(const wchar_t * str1, const wchar_t * str2, unsigned char ignore_case) {
+	return CompareStringOrdinal(
+		str1, -1, str2, -1, ignore_case
 	);
 }
 
 /// <summary>
-/// this is legacy aka "pre vista" solution 
+/// This is to be used for "UI sting comparisons" or sorting and a such
+/// this is locale sensitive, legacy aka "pre vista" solution 
 /// when locales had ID's not names
 /// and when CompareStringEx was not
 /// </summary>

--- a/src/winfile_internals.c
+++ b/src/winfile_internals.c
@@ -1,0 +1,47 @@
+/*
+2018-04-30	dbj@dbj.org		created
+*/
+#include <windows.h>
+#include <ntddkbd.h>
+#include "winfile_internals.h"
+
+/// <summary>
+/// non-linguistic byte level comparison of strings
+/// note: RtlCompare[Unicode]String is called from CompareString[Ex]
+/// </summary>
+int winfile_exact_string_compareA(const char * str1, const char * str2, unsigned char CaseInSensitive) {
+	return RtlCompareString(
+		str1, str2, CaseInSensitive
+	);
+}
+
+int winfile_exact_string_compareW(const wchar_t * str1, const wchar_t * str2, unsigned char CaseInSensitive) {
+	return RtlCompareUnicodeString(
+		str1, str2, CaseInSensitive
+	);
+}
+
+/// <summary>
+/// this is legacy aka "pre vista" solution 
+/// when locales had ID's not names
+/// and when CompareStringEx was not
+/// </summary>
+int winfile_ui_string_compare(LPCTSTR str1, LPCTSTR str2, unsigned char ignore_case)
+{
+	/// <summary>
+	/// it is highly unlikely the user will change the
+	/// locale between the calls, so we could have this
+	/// as static 
+	/// </summary>
+	/* LCID aka DWORD */ unsigned long
+		current_locale = GetUserDefaultLCID(); // not LOCALE_INVARIANT
+
+	return CompareString(
+		/* _In_ LCID    */ current_locale,
+		/* _In_ DWORD   */ ignore_case == 1 ? LINGUISTIC_IGNORECASE : NORM_LINGUISTIC_CASING,
+		/* _In_ LPCTSTR */ str1,
+		/* _In_ int     */ -1,
+		/* _In_ LPCTSTR */ str2,
+		/* _In_ int     */ -1
+	);
+}

--- a/src/winfile_internals.h
+++ b/src/winfile_internals.h
@@ -1,0 +1,32 @@
+#pragma once
+
+/// <summary>
+/// this is where we keep reusable solutions
+/// the C interface
+/// </summary>
+
+
+#ifdef __cplusplus
+extern "C" {            /* Assume C declarations for C++ */
+#endif /* __cplusplus */
+
+						/*
+						use string comparisons bellow to combat:
+						warning C6400:
+						Using 'lstrcmpi' to perform a case-insensitive compare
+						Yields unexpected results in non-English locales.
+						*/
+	int winfile_exact_string_compareA(const char * str1, const char * str2, unsigned char CaseInSensitive);
+	int winfile_exact_string_compareW(const wchar_t * str1, const wchar_t * str2, unsigned char CaseInSensitive);
+
+#if _UNICODE
+#define winfile_exact_string_compare binary_string_compareW
+#else
+#define winfile_exact_string_compare binary_string_compareA
+#endif
+
+	int winfile_ui_string_compare(LPCTSTR str1, LPCTSTR str2, unsigned char ignore_case);
+
+#ifdef __cplusplus
+} // extern "C" 
+#endif /* __cplusplus */

--- a/src/winfile_internals.h
+++ b/src/winfile_internals.h
@@ -1,28 +1,173 @@
 #pragma once
 
 /// <summary>
-/// this is where we keep reusable solutions
-/// the C interface
+/// this is where we keep reusable 'things'
+/// or atifacts one will use to sort out 
+/// (for example) vs2017 code analyzer 
+/// good advice and warnings
+/// 
+/// c++ stuff one can keep here for later or
+/// never use it, it depends on the course 
+/// of events
 /// </summary>
+#ifdef __cplusplus
 
+#include <sysinfoapi.h>
+// avoid min/max macros 
+#define NOMINMAX
+// mutex is (much) lighter on cpu vs std::atomic_flag
+#define WINFILE_STD_MUTEX_USE 
+
+#include <string>
+#include <map>
+#include <vector>
+#include <algorithm>
+#include <cwctype>
+#ifndef WINFILE_STD_MUTEX_USE 
+#include <atomic>
+#else
+#include <mutex>
+#endif
+
+namespace winfile {
+	namespace internal {
+
+		using namespace std;
+
+#ifndef WINFILE_STD_MUTEX_USE 
+		struct lock_unlock final {
+			std::atomic_flag atom_flag_ = ATOMIC_FLAG_INIT;
+
+			lock_unlock() { while (atom_flag_.test_and_set()); }
+			~lock_unlock() { atom_flag_.clear(); }
+		};
+#else
+		struct lock_unlock final {
+			std::mutex mux_;
+
+			lock_unlock() { mux_.lock(); }
+			~lock_unlock() { mux_.unlock(); }
+		};
+#endif
+
+		template <typename T>
+		class guardian final {
+		public:
+			typedef T value_type;
+			value_type load() const {
+				lock_unlock locker_;
+				return treasure_;
+			}
+			value_type store(value_type new_value) const {
+				lock_unlock locker_;
+				return treasure_ = new_value;
+			}
+		private:
+			mutable value_type treasure_{};
+		};
+
+		/// <summary>
+		/// argument is a reference 
+		/// and is "lowerized" in place
+		/// </summary>
+		inline void lowerize(wstring & key) {
+			transform(key.begin(), key.end(), key.begin(), std::towlower);
+		};
+
+		// std::equal has many overloads
+		// it is less error prone to have here
+		// and use this one we exactly need
+		template<class InputIt1, class InputIt2>
+		bool equal_(InputIt1 first1, InputIt1 last1, InputIt2 first2)
+		{
+			for (; first1 != last1; ++first1, ++first2) {
+				if (!(*first1 == *first2)) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		/// <summary>
+		/// is Lhs prefix to Rhs
+		/// L must be shorter than R
+		/// </summary>
+		inline  bool  is_prefix(
+			const std::wstring_view & lhs, const std::wstring_view & rhs
+		)
+		{
+			_ASSERTE(lhs.size() > 0);
+			_ASSERTE(rhs.size() > 0);
+
+			// "predefined" can not be a prefix to "pre" 
+			// opposite is true
+			if (lhs.size() > rhs.size()) return false;
+
+			return equal_(
+				lhs.begin(),
+				lhs.end(),
+				rhs.begin());
+		}
+
+		// return e.g. L"C:\windows\system32"
+		inline const std::wstring windir()
+		{
+			lock_unlock padlock_;
+			static wchar_t  result_buf[BUFSIZ]{};
+			static auto retval = ::GetSystemDirectoryW(
+				result_buf,
+				BUFSIZ
+			);
+			_ASSERTE(retval);
+			return wstring{ result_buf };
+		}
+
+		// DBJ: what happens if there is no drive C: ?
+		// we get the system drive letter
+		// the first 3 chars that is, e.g. L"C:\\"
+		inline const std::wstring windrive()
+		{
+			lock_unlock padlock_;
+			static wstring result = windir().substr(0, 3);
+			_ASSERTE(result.size() == 3);
+			return result;
+		}
+
+		extern "C" inline auto
+			add_backslash(wstring & path_)
+		{
+			static auto CHAR_BACKSLASH{ L'\\' };
+			if (path_.back() != CHAR_BACKSLASH) {
+				path_.append(wstring{ CHAR_BACKSLASH });
+			}
+			return path_.size();
+		}
+
+	} // internal
+} // winfile
+
+#endif // __cpluspus
+
+  /*
+  and here is the C interface to winfile internals
+  */
 
 #ifdef __cplusplus
 extern "C" {            /* Assume C declarations for C++ */
 #endif /* __cplusplus */
 
-						/*
-						use string comparisons bellow to combat:
-						warning C6400:
-						Using 'lstrcmpi' to perform a case-insensitive compare
-						Yields unexpected results in non-English locales.
-						*/
-	int winfile_exact_string_compareA(const char * str1, const char * str2, unsigned char CaseInSensitive);
-	int winfile_exact_string_compareW(const wchar_t * str1, const wchar_t * str2, unsigned char CaseInSensitive);
+	/*
+	use string comparisons bellow to solve:
+	warning C6400: Using 'lstrcmpiW' to perform a case-insensitive compare
+	Yields unexpected results in non-English locales.
+	*/
+	int winfile_ordinal_string_compareA(const char * str1, const char * str2, unsigned char ignore_case);
+	int winfile_ordinal_string_compareW(const wchar_t * str1, const wchar_t * str2, unsigned char ignore_case);
 
 #if _UNICODE
-#define winfile_exact_string_compare binary_string_compareW
+#define winfile_ordinal_string_compare winfile_ordinal_string_compareW
 #else
-#define winfile_exact_string_compare binary_string_compareA
+#define winfile_exact_string_compare winfile_ordinal_string_compareA
 #endif
 
 	int winfile_ui_string_compare(LPCTSTR str1, LPCTSTR str2, unsigned char ignore_case);


### PR DESCRIPTION
to solve (few ot these):

d:\github\winfile\src\wfutil.c(859): warning C6400: Using 'lstrcmpiW' to perform a case-insensitive compare to constant string 'NTFS'.  Yields unexpected results in non-English locales.

I have created winfile_internals h and c

idea is to keep (re usable) solutions in there ..

as for C6400, I would not want to apply it to the code base because I am not sure when to use 

ordinal string comparison 

or when to use

locale sensitive string comparison

there are not that many places in the code where this needs to be applied so if someone points me where to use which I can do that too ..

code is properly commented.