### PR TITLE
Ignore directories with blank names when building goto cache

### DIFF
--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -345,7 +345,7 @@ BOOL BuildDirectoryBagOValues(BagOValues<PDNODE> *pbov, vector<PDNODE> *pNodes, 
 
 		// for all directories at this level, insert into BagOValues
 
-		if ((lfndta.fd.dwFileAttributes & ATTR_DIR) == 0 || ISDOTDIR(lfndta.fd.cFileName))
+		if ((lfndta.fd.dwFileAttributes & ATTR_DIR) == 0 || ISDOTDIR(lfndta.fd.cFileName) || wcscmp(lfndta.fd.cFileName, L"") == 0)
 		{
 			bFound = WFFindNext(&lfndta);
 			continue;


### PR DESCRIPTION
Ignoring directories with blank names while building the goto cache fixes the crash reported in https://github.com/Microsoft/winfile/issues/194