### PR TITLE
Getting ExeView to run in x64

### DIFF
--- a/tools/ExeView/filllb.cpp
+++ b/tools/ExeView/filllb.cpp
@@ -74,7 +74,7 @@ BOOL FillLBWithNewExeHeader (HWND hWnd, PEXEINFO pExeInfo)
     PNEWEXE     pne = &(pExeInfo->NewHdr);
     LPSTR       lp = (LPSTR)szBuff;
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );
@@ -233,7 +233,7 @@ BOOL FillLBWithOldExeHeader (HWND hWnd, PEXEINFO pExeInfo )
     LPSTR lp = (LPSTR)szBuff;
     POLDEXE pOldExeHdr = &(pExeInfo->OldHdr);
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );
@@ -327,7 +327,7 @@ BOOL FillLBWithEntryTable (HWND hWnd, PEXEINFO pExeInfo )
     BYTE  bBundles;
     BYTE  bFlags;
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );
@@ -454,7 +454,7 @@ BOOL FillLBWithSegments (HWND hWnd, PEXEINFO pExeInfo )
     PSEGENTRY pSeg = GetSegEntry( pExeInfo, 0 );
     int       i=0;
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );
@@ -518,8 +518,8 @@ BOOL FillLBWithResources (HWND hWnd, PEXEINFO pExeInfo )
     LPCSTR   lpn;
     PRESTYPE prt = pExeInfo->pResTable;
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
-    #define SETDATA() SendMessage( hWnd, LB_SETITEMDATA, , (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
+    #define SETDATA() SendMessage( hWnd, LB_SETITEMDATA, , (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );
@@ -617,7 +617,7 @@ BOOL FillLBWithResidentNames (HWND hWnd, PEXEINFO pExeInfo )
     LPSTR lp = (LPSTR)szBuff;
     PNAME pName = pExeInfo->pResidentNames;
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );
@@ -682,7 +682,7 @@ BOOL FillLBWithImportedNames (HWND hWnd, PEXEINFO pExeInfo )
     LPSTR lp = (LPSTR)szBuff;
     PNAME pName = pExeInfo->pImportedNames;
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );
@@ -743,7 +743,7 @@ BOOL FillLBWithNonResidentNames (HWND hWnd, PEXEINFO pExeInfo )
     LPSTR lp = (LPSTR)szBuff;
     PNAME pName = pExeInfo->pNonResidentNames;
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );

--- a/tools/ExeView/init.cpp
+++ b/tools/ExeView/init.cpp
@@ -130,7 +130,7 @@ BOOL InitInstance (HINSTANCE hInstance, int nCmdShow)
     if (!hWnd)
         return FALSE;
 
-    SendMessage( hWnd, LB_SETTABSTOPS, 1, (LONG)(LPINT)&tabs );
+    SendMessage( hWnd, LB_SETTABSTOPS, 1, (LPARAM)(LPINT)&tabs );
     SendMessage( hWnd, WM_SETFONT, (WPARAM)GetStockObject(SYSTEM_FIXED_FONT), 0L );
 
     hWnd = CreateWindow( "BUTTON", "Old Header", WS_CHILD|WS_VISIBLE,

--- a/tools/ExeView/res.cpp
+++ b/tools/ExeView/res.cpp
@@ -174,7 +174,7 @@ BOOL DisplayResource ( PEXEINFO pExeInfo, PRESTYPE prt, PRESINFO pri )
 
                 lpProc = MakeProcInstance(NameTableProc, ghInst );
                 nErr = !DialogBoxParam( ghInst, "NAMETABLE_DLG", ghWndMain, lpProc,
-                    (LONG)lprp );
+                    (LPARAM)lprp );
                 FreeProcInstance( lpProc );
             }
             break;
@@ -187,7 +187,7 @@ BOOL DisplayResource ( PEXEINFO pExeInfo, PRESTYPE prt, PRESINFO pri )
 
                 // Re-use the NAMETABLE_DLG with a different DlgProc
                 nErr = !DialogBoxParam( ghInst, "NAMETABLE_DLG", ghWndMain, lpProc,
-                    (LONG)lprp );
+                    (LPARAM)lprp );
                 FreeProcInstance( lpProc );
             }
             break;
@@ -200,7 +200,7 @@ BOOL DisplayResource ( PEXEINFO pExeInfo, PRESTYPE prt, PRESINFO pri )
 
                 // Re-use the NAMETABLE_DLG with a different DlgProc
                 nErr = !DialogBoxParam( ghInst, "NAMETABLE_DLG", ghWndMain, lpProc,
-                    (LONG)lprp );
+                    (LPARAM)lprp );
                 FreeProcInstance( lpProc );
             }
             break;
@@ -213,7 +213,7 @@ BOOL DisplayResource ( PEXEINFO pExeInfo, PRESTYPE prt, PRESINFO pri )
 
                 // Re-use the NAMETABLE_DLG with a different DlgProc
                 nErr = !DialogBoxParam( ghInst, "NAMETABLE_DLG", ghWndMain, lpProc,
-                    (LONG)lprp );
+                    (LPARAM)lprp );
                 FreeProcInstance( lpProc );
             }
             break;
@@ -226,7 +226,7 @@ BOOL DisplayResource ( PEXEINFO pExeInfo, PRESTYPE prt, PRESINFO pri )
 
                 // Re-use the NAMETABLE_DLG with a different DlgProc
                 nErr = !DialogBoxParam( ghInst, "NAMETABLE_DLG", ghWndMain, lpProc,
-                    (LONG)lprp );
+                    (LPARAM)lprp );
                 FreeProcInstance( lpProc );
             }
             break;
@@ -239,7 +239,7 @@ BOOL DisplayResource ( PEXEINFO pExeInfo, PRESTYPE prt, PRESINFO pri )
 
                 // Re-use the NAMETABLE_DLG with a different DlgProc
                 nErr = !DialogBoxParam( ghInst, "NAMETABLE_DLG", ghWndMain, lpProc,
-                    (LONG)lprp );
+                    (LPARAM)lprp );
                 FreeProcInstance( lpProc );
             }
             break;
@@ -252,7 +252,7 @@ BOOL DisplayResource ( PEXEINFO pExeInfo, PRESTYPE prt, PRESINFO pri )
 
                 // Re-use the GRAPHIC_DLG with a different DlgProc
                 nErr = !DialogBoxParam( ghInst, "GRAPHIC_DLG", ghWndMain, lpProc,
-                    (LONG)lprp );
+                    (LPARAM)lprp );
                 FreeProcInstance( lpProc );
             }
             break;
@@ -265,7 +265,7 @@ BOOL DisplayResource ( PEXEINFO pExeInfo, PRESTYPE prt, PRESINFO pri )
 
                 // Re-use the GRAPHIC_DLG with a different DlgProc
                 nErr = !DialogBoxParam( ghInst, "GRAPHIC_DLG", ghWndMain, lpProc,
-                    (LONG)lprp );
+                    (LPARAM)lprp );
                 FreeProcInstance( lpProc );
             }
             break;
@@ -391,7 +391,7 @@ BOOL FillLBWithNameTable (HWND hWnd, LPRESPACKET lprp)
     LPNAMEENTRY lpne = (LPNAMEENTRY)lprp->lpMem;
     LONG        lSize = 0;
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );
@@ -524,7 +524,7 @@ BOOL FillLBWithIconGroup (HWND hWnd, LPRESPACKET lprp)
 
 
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );
@@ -636,7 +636,7 @@ BOOL FillLBWithCursorGroup (HWND hWnd, LPRESPACKET lprp)
     LPCURSORDIR lpcd = (LPCURSORDIR)lprp->lpMem;
 
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );
@@ -747,7 +747,7 @@ BOOL FillLBWithAccelTable (HWND hWnd, LPRESPACKET lprp)
     LPACCELENTRY lpae = (LPACCELENTRY)lprp->lpMem;
 
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );
@@ -886,7 +886,7 @@ BOOL FillLBWithStringTable (HWND hWnd, LPRESPACKET lprp)
     LPSTR lpS, lp = (LPSTR)szBuff;
     int   nI, nOrdinal;
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     nOrdinal = (lprp->pri->wID-1) & 0x7fff;
     nOrdinal <<= 4;
@@ -1008,7 +1008,7 @@ BOOL FillLBWithFontDir (HWND hWnd, LPRESPACKET lprp)
     nFonts = *((LPINT)lprp->lpMem);
     lpfe = (LPFONTENTRY)(lprp->lpMem + sizeof(WORD));
 
-    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LONG)lp )
+    #define ADDITEM() SendMessage( hWnd, LB_ADDSTRING, 0, (LPARAM)lp )
 
     SendMessage( hWnd, WM_SETREDRAW, 0, 0L );
     SendMessage( hWnd, LB_RESETCONTENT, 0, 0L );


### PR DESCRIPTION
Fixing calls to SendMessage() that cast the last parameter to LONG, changing to LPARAM.

The one that was causing ExeView to crash at startup was in init.cpp, SendMessage with LB_SETTABSTOPS.