### PR TITLE
WINFILE.INI's location need to be flexible to be more useful

### DIFF
--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -1009,8 +1009,7 @@ InitFileManager(
    lstrcpy(szTheINIFile, szBaseINIFile);
    dwRetval = GetEnvironmentVariable(TEXT("APPDATA"), szBuffer, MAXPATHLEN);
    if (dwRetval == 0 && GetLastError() == ERROR_ENVVAR_NOT_FOUND) {
-	   MessageBox(NULL, TEXT("a"), TEXT("b"), NULL);
-	   WCHAR         szTempBuffer[2 * MAXPATHLEN - 16];
+	   WCHAR szTempBuffer[2 * MAXPATHLEN - 16];
 	   dwRetval = GetEnvironmentVariable(TEXT("USERPROFILE"), szTempBuffer, MAXPATHLEN);
 	   if (dwRetval > 0) {
 		   wsprintf(szBuffer, TEXT("%s%s"), szTempBuffer, TEXT("\\APPDATA\\Roaming"));

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -1008,6 +1008,15 @@ InitFileManager(
    // setup ini file location
    lstrcpy(szTheINIFile, szBaseINIFile);
    dwRetval = GetEnvironmentVariable(TEXT("APPDATA"), szBuffer, MAXPATHLEN);
+   if (dwRetval == 0 && GetLastError() == ERROR_ENVVAR_NOT_FOUND) {
+	   MessageBox(NULL, TEXT("a"), TEXT("b"), NULL);
+	   WCHAR         szTempBuffer[2 * MAXPATHLEN - 16];
+	   dwRetval = GetEnvironmentVariable(TEXT("USERPROFILE"), szTempBuffer, MAXPATHLEN);
+	   if (dwRetval > 0) {
+		   wsprintf(szBuffer, TEXT("%s%s"), szTempBuffer, TEXT("\\APPDATA\\Roaming"));
+		   dwRetval = dwRetval + 16;
+	   }
+   }
    if (dwRetval > 0 && dwRetval <= (DWORD)(MAXPATHLEN - lstrlen(szRoamINIPath) - 1 - lstrlen(szBaseINIFile) - 1)) {
 	   wsprintf(szTheINIFile, TEXT("%s%s"), szBuffer, szRoamINIPath);
 	   if (CreateDirectory(szTheINIFile, NULL) || GetLastError() == ERROR_ALREADY_EXISTS) {


### PR DESCRIPTION
WinPE don't have APPDATA environment variable, thus WinFile is unable to write and read config file. Seems USERPROFILE environment variable works, not sure if older systems have this environment variable. So let it be the second choice now.
Appreciate for any advice or discussion