### PR TITLE
Ctrl - Alt - Letter

### DIFF
--- a/src/treectl.c
+++ b/src/treectl.c
@@ -3085,12 +3085,10 @@ SameSelection:
       }
 
       default:
-#if 0
-          // OLD: select disk with that letter
-          if (GetKeyState(VK_CONTROL) < 0)
+        // Select disc by pressing CTRL + ALT + letter
+        if ((GetKeyState(VK_CONTROL) < 0) && (GetKeyState(VK_MENU) < 0))
             return SendMessage(hwndDriveBar, uMsg, wParam, lParam);
-#endif
-         return -1L;
+
       }
       break;
 

--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -924,17 +924,10 @@ DirWndProc(
          return -2;
 
       default:
-         {
-#if 0
-          // check for Ctrl-[DRIVE LETTER] and pass on to drives
-          // window
-
-          if ((GetKeyState(VK_CONTROL) < 0) && hwndDriveBar) {
-               return SendMessage(hwndDriveBar, uMsg, wParam, lParam);
-          }
-#endif
-            break;
-         }
+        // Select disc by pressing CTRL + ALT + letter
+        if ((GetKeyState(VK_CONTROL) < 0) && (GetKeyState(VK_MENU) < 0) && hwndDriveBar)
+              return SendMessage(hwndDriveBar, uMsg, wParam, lParam);
+        break;
       }
       return -1;
 

--- a/src/wfsearch.c
+++ b/src/wfsearch.c
@@ -463,7 +463,7 @@ FillSearchLB(HWND hwndLB, LPWSTR szSearchFileSpec, BOOL bRecurse, BOOL bIncludeS
    INT iFileCount;
    WCHAR szFileSpec[MAXPATHLEN+1];
    WCHAR szPathName[MAXPATHLEN+1];
-   WCHAR szWildCard[20];
+   WCHAR szWildCard[MAXPATHLEN+1];
    LPWCH lpszCurrentFileSpecStart;
    LPWCH lpszCurrentFileSpecEnd;
    LPXDTALINK lpStart = NULL;


### PR DESCRIPTION
In the original Filemanager one could select a drive by CTRL + letter, which I used heavily.
With the new FileManager this did not work anymore, due to CTRL-C beeing used for Copy/Paste. So far so good
Now pressing CTRL + ALT + letter selects drive

Furthermore fixed a too short wildcard during search.

See the comments on the PR
