### PR TITLE
Various little fixes

### DIFF
--- a/src/treectl.c
+++ b/src/treectl.c
@@ -3089,6 +3089,7 @@ SameSelection:
         if ((GetKeyState(VK_CONTROL) < 0) && (GetKeyState(VK_MENU) < 0))
             return SendMessage(hwndDriveBar, uMsg, wParam, lParam);
 
+        return -1L;
       }
       break;
 

--- a/src/treectl.c
+++ b/src/treectl.c
@@ -3085,12 +3085,10 @@ SameSelection:
       }
 
       default:
-#if 0
-          // OLD: select disk with that letter
-          if (GetKeyState(VK_CONTROL) < 0)
+        // Select disc by pressing CTRL + ALT + letter
+        if ((GetKeyState(VK_CONTROL) < 0) && (GetKeyState(VK_MENU) < 0))
             return SendMessage(hwndDriveBar, uMsg, wParam, lParam);
-#endif
-         return -1L;
+
       }
       break;
 

--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -2829,6 +2829,30 @@ UsedAltname:
                   // if filename part, strip path
                   StripPath(szFile);
                }
+               else
+               {
+                 // Resolve reparse point
+                 DecodeReparsePoint(szPath, szFile, szTemp, MAXPATHLEN);
+
+                 // Check if it started with namespace root
+                 int prefix = 0;
+                 if (lstrlen(szTemp) >= SZ_NS_ROOT_SIZE)
+                   if (!wcsncmp(szTemp, SZ_NS_ROOT, SZ_NS_ROOT_SIZE))
+                     prefix = SZ_NS_ROOT_SIZE;
+                 
+                 // Check if it was a relatve or absolute reparse point
+                 if (isalpha(szTemp[prefix])) {
+                   if (szTemp[prefix + 1] == CHAR_COLON) {
+                     // junction and absolute symlink
+                     lstrcpy(szFile, &szTemp[prefix]);
+                   }
+                   else {
+                     // relative symlink
+                     lstrcpy(szFile, szPath);
+                     lstrcat(szFile, &szTemp[prefix]);      // fully qualified
+                   }
+                 }
+               }
             }
             //
             // parent dir?

--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -924,17 +924,10 @@ DirWndProc(
          return -2;
 
       default:
-         {
-#if 0
-          // check for Ctrl-[DRIVE LETTER] and pass on to drives
-          // window
-
-          if ((GetKeyState(VK_CONTROL) < 0) && hwndDriveBar) {
-               return SendMessage(hwndDriveBar, uMsg, wParam, lParam);
-          }
-#endif
-            break;
-         }
+        // Select disc by pressing CTRL + ALT + letter
+        if ((GetKeyState(VK_CONTROL) < 0) && (GetKeyState(VK_MENU) < 0) && hwndDriveBar)
+              return SendMessage(hwndDriveBar, uMsg, wParam, lParam);
+        break;
       }
       return -1;
 

--- a/src/wfsearch.c
+++ b/src/wfsearch.c
@@ -463,7 +463,7 @@ FillSearchLB(HWND hwndLB, LPWSTR szSearchFileSpec, BOOL bRecurse, BOOL bIncludeS
    INT iFileCount;
    WCHAR szFileSpec[MAXPATHLEN+1];
    WCHAR szPathName[MAXPATHLEN+1];
-   WCHAR szWildCard[20];
+   WCHAR szWildCard[MAXPATHLEN+1];
    LPWCH lpszCurrentFileSpecStart;
    LPWCH lpszCurrentFileSpecEnd;
    LPXDTALINK lpStart = NULL;

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -147,6 +147,8 @@ INT atoiW(LPWSTR sz);
 #define SZ_DOTSTAR        TEXT(".*")
 #define SZ_COLONONE       TEXT(":1")
 #define SZ_SPACEDASHSPACE TEXT(" - ")
+#define SZ_NS_ROOT        TEXT("\\??\\")
+#define SZ_NS_ROOT_SIZE   (sizeof(SZ_NS_ROOT) - 1) / sizeof(wchar_t)
 
 
 #define CHAR_DASH TEXT('-')


### PR DESCRIPTION
* A fixed drive can now be selected via CTRL + ALT + letter. The original version did this with CTRL + letter
* Fixed a too short wildcard in file search
* Following reparse points in the right directory pane was bogus

See comments with commits