### PR TITLE
Double clicking a relative or absolute symbolic link or a junction in…

### DIFF
--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -2829,6 +2829,30 @@ UsedAltname:
                   // if filename part, strip path
                   StripPath(szFile);
                }
+               else
+               {
+                 // Resolve reparse point
+                 DecodeReparsePoint(szPath, szFile, szTemp, MAXPATHLEN);
+
+                 // Check if it started with namespace root
+                 int prefix = 0;
+                 if (lstrlen(szTemp) >= SZ_NS_ROOT_SIZE)
+                   if (!wcsncmp(szTemp, SZ_NS_ROOT, SZ_NS_ROOT_SIZE))
+                     prefix = SZ_NS_ROOT_SIZE;
+                 
+                 // Check if it was a relatve or absolute reparse point
+                 if (isalpha(szTemp[prefix])) {
+                   if (szTemp[prefix + 1] == CHAR_COLON) {
+                     // junction and absolute symlink
+                     lstrcpy(szFile, &szTemp[prefix]);
+                   }
+                   else {
+                     // relative symlink
+                     lstrcpy(szFile, szPath);
+                     lstrcat(szFile, &szTemp[prefix]);      // fully qualified
+                   }
+                 }
+               }
             }
             //
             // parent dir?

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -147,6 +147,8 @@ INT atoiW(LPWSTR sz);
 #define SZ_DOTSTAR        TEXT(".*")
 #define SZ_COLONONE       TEXT(":1")
 #define SZ_SPACEDASHSPACE TEXT(" - ")
+#define SZ_NS_ROOT        TEXT("\\??\\")
+#define SZ_NS_ROOT_SIZE   (sizeof(SZ_NS_ROOT) - 1) / sizeof(wchar_t)
 
 
 #define CHAR_DASH TEXT('-')


### PR DESCRIPTION
### General
Double clicking a relative or absolute symbolic link or a junction in the right directory pane resulted in navigating to bogus directory locations.
Now navigation in the right pane works properly and reparse points are resolved properly.

### How to test
You might test this by running the below .bat file
[WinFilerReparseTest.zip](https://github.com/microsoft/winfile/files/7894582/WinFilerReparseTest.zip)
and by downloading ln.exe from https://schinagl.priv.at/nt/ln/ln64.zip and placing it in the same directory as the above .bat file

The bat file creates a simple structure with relative and absolute symbolic links and a junction, so that you can click around with winfile in the right pane.

A little sidetrack ... check https://schinagl.priv.at/nt/ln/ln.html ;-) it does much more reparse point magic. sry for the ad
