### PR TITLE
Double clicking a relative or absolute symbolic link or a junction in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ In summary v10.0 has the following changes/new features compared to original_plu
 
 1. OLE drag/drop support
 2. control characters (e.g., ctrl+C) map to current short cut (e.g., `ctrl+c` -> `copy`)
-instead of changing drives
+instead of changing drives. Change drives now via CTRL + ALT + letter
 3. cut (`ctrl+X`) followed by paste (`ctrl+V`) translates into a file move as one would expect
 4. left and right arrows in the tree view expand and collapse folders like in the Explorer
 5. added context menus in both panes

--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -2821,7 +2821,7 @@ UsedAltname:
 
          if (hwndDir) {
 
-            // reparse point; szFile is full path
+            // reparse point; szFile is filename only
             if (lpxdta->dwAttrs & (ATTR_JUNCTION | ATTR_SYMBOLIC))
             {
                if (iSelType & 8) 
@@ -2831,7 +2831,7 @@ UsedAltname:
                }
                else
                {
-                 // reparse point also need fully qualified path as return
+                 // reparse points also need fully qualified path as return
                  lstrcpy(szTemp, szPath);
 
                  lstrcat(szTemp, szFile);

--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -2829,6 +2829,14 @@ UsedAltname:
                   // if filename part, strip path
                   StripPath(szFile);
                }
+               else
+               {
+                 // reparse point also need fully qualified path as return
+                 lstrcpy(szTemp, szPath);
+
+                 lstrcat(szTemp, szFile);
+                 lstrcpy(szFile, szTemp);
+               }
             }
             //
             // parent dir?


### PR DESCRIPTION
### General
Double clicking a relative or absolute symbolic link or a junction in the right directory pane resulted in navigating to bogus directory locations.
Now navigation in the right pane works properly and reparse points are resolved properly.

### How to test
You might test this by running the below .bat file
[WinFileReparseTest.zip](https://github.com/microsoft/winfile/files/7921422/WinFileReparseTest.zip)
and by downloading ln.exe from https://schinagl.priv.at/nt/ln/ln64.zip and placing it in the same directory as the above .bat file

The bat file creates a simple structure with relative and absolute symbolic links and a junction, so that you can click around with winfile in the right pane. You can also create the dir structure with mklink.exe if you would like to avoid the above ln.exe

A little sidetrack ... check https://schinagl.priv.at/nt/ln/ln.html ;-) it does much more reparse point magic. Sry for the ad ;-)



