### PR TITLE
Use GetDiskFreeSpaceEx to report larger amounts of free space

### DIFF
--- a/src/numfmt.c
+++ b/src/numfmt.c
@@ -81,14 +81,3 @@ AddOrder:
    return(szBuf);
 }
 
-
-LARGE_INTEGER
-TriMultiply(DWORD dw1, DWORD dw2, DWORD dwSmall)
-{
-   LARGE_INTEGER Result;
-
-   Result.QuadPart = UInt32x32To64(dw1, dw2);
-   Result.QuadPart = Result.QuadPart * dwSmall;
-
-   return Result;
-}

--- a/src/numfmt.h
+++ b/src/numfmt.h
@@ -21,5 +21,3 @@ LPTSTR ShortSizeFormatInternal(LPTSTR szBuf, LARGE_INTEGER qw);
 
 #define LARGE_INTEGER_NULL(q) ((q).LowPart = 0, (q).HighPart = 0)
 
-LARGE_INTEGER TriMultiply(DWORD dw1, DWORD dw2, DWORD dwSmall);
-

--- a/src/wfdos.c
+++ b/src/wfdos.c
@@ -11,32 +11,22 @@
 
 #include "winfile.h"
 
-// Warning: assumes bytes per sector < 2 gigs
-
 VOID
 GetDiskSpace(DRIVE drive,
-   PLARGE_INTEGER pqFreeSpace,
-   PLARGE_INTEGER pqTotalSpace)
+   PULARGE_INTEGER pqFreeSpace,
+   PULARGE_INTEGER pqTotalSpace)
 {
-   DWORD dwSectorsPerCluster;
-   DWORD dwBytesPerSector;
-   DWORD dwFreeClusters;
-   DWORD dwTotalClusters;
+   ULARGE_INTEGER qBytesAvailableToCaller;
 
    TCHAR szDriveRoot[] = SZ_ACOLONSLASH;
 
    DRIVESET(szDriveRoot, drive);
 
-   if (GetDiskFreeSpace(szDriveRoot,
-      &dwSectorsPerCluster,
-      &dwBytesPerSector,
-      &dwFreeClusters,
-      &dwTotalClusters)) {
+   if (!GetDiskFreeSpaceEx(szDriveRoot,
+      &qBytesAvailableToCaller,
+      pqTotalSpace,
+      pqFreeSpace)) {
 
-      *pqFreeSpace = TriMultiply(dwFreeClusters,dwSectorsPerCluster,dwBytesPerSector);
-      *pqTotalSpace= TriMultiply(dwTotalClusters,dwSectorsPerCluster,dwBytesPerSector);
-
-   } else {
       LARGE_INTEGER_NULL(*pqFreeSpace);
       LARGE_INTEGER_NULL(*pqTotalSpace);
    }

--- a/src/wfinfo.c
+++ b/src/wfinfo.c
@@ -103,16 +103,16 @@ U_CLOSE(Type)
 
 U_HEAD(Space)
 
-   LARGE_INTEGER qFreeSpace;
-   LARGE_INTEGER qTotalSpace;
+   ULARGE_INTEGER qFreeSpace;
+   ULARGE_INTEGER qTotalSpace;
 
    IF_READ(Space)
       GetDiskSpace(drive, &qFreeSpace, &qTotalSpace);
 
       ENTER_MODIFY(Space)
 
-         aDriveInfo[drive].qFreeSpace = qFreeSpace;
-         aDriveInfo[drive].qTotalSpace= qTotalSpace;
+         aDriveInfo[drive].qFreeSpace.QuadPart = qFreeSpace.QuadPart;
+         aDriveInfo[drive].qTotalSpace.QuadPart = qTotalSpace.QuadPart;
 
       EXIT_MODIFY(Space)
 

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -372,7 +372,7 @@ VOID UpdateMoveStatus(DWORD dwEffect);
 
 // WFDOS.C
 
-VOID GetDiskSpace(DRIVE drive, PLARGE_INTEGER pqFreeSpace, PLARGE_INTEGER pqTotalSpace);
+VOID GetDiskSpace(DRIVE drive, PULARGE_INTEGER pqFreeSpace, PULARGE_INTEGER pqTotalSpace);
 INT   ChangeVolumeLabel(DRIVE, LPTSTR);
 DWORD GetVolumeLabel(DRIVE, LPTSTR*, BOOL);
 DWORD


### PR DESCRIPTION
This is to fix issue #257 .

GetDiskFreeSpaceEx returns unsigned 64 bit values; internally winfile is still using signed 64 bit values.