### PR TITLE
Inherit ACLs from parent after rename

### DIFF
--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -3348,10 +3348,28 @@ FileMove(LPTSTR pFrom, LPTSTR pTo, PBOOL pbErrorOnDest, BOOL bSilent)
    *pbErrorOnDest = FALSE;
 
 TryAgain:
-    if (MoveFile((LPTSTR)pFrom, (LPTSTR)pTo))
+    if (MoveFile((LPTSTR)pFrom, (LPTSTR)pTo)) {
+        ACL EmptyAcl;
         result = 0;
-    else
+
+        //
+        //  Enable ACL inheritance, updating the ACL on the file from its new
+        //  parent.  Note this requires Windows 2000 and above.  There's not
+        //  much we can do if it fails, since the rename already occurred.
+        //
+
+        InitializeAcl(&EmptyAcl, sizeof(EmptyAcl), ACL_REVISION);
+        SetNamedSecurityInfo((LPTSTR)pTo,
+                             SE_FILE_OBJECT,
+                             DACL_SECURITY_INFORMATION | UNPROTECTED_DACL_SECURITY_INFORMATION,
+                             NULL,
+                             NULL,
+                             &EmptyAcl,
+                             NULL);
+
+    } else {
         result = GetLastError();
+    }
 
     // try to create the destination if it is not there
 

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -27,6 +27,7 @@
 #include "fmifs.h"
 #include <shellapi.h>
 #include <shlwapi.h>
+#include <aclapi.h>
 #include <strsafe.h>
 #include "suggest.h"
 #include "numfmt.h"


### PR DESCRIPTION
NTFS stores ACLs per file.  When a file is moved across directories, ACLs are not changed by the file system.  Providing inherited ACL semantics works in explorer by enabling inheritance on the target after the move, causing its ACL to be updated as a second step.  This change implements that logic.

This is to fix #276 .