### PR TITLE
The pathes, which shall be cached for the Goto dialog can be configur…

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ instead of changing drives. Change drives now via CTRL + ALT + letter
 4. left and right arrows in the tree view expand and collapse folders like in the Explorer
 5. added context menus in both panes
 6. improved the means by which icons are displayed for files
-7. F12 runs notepad or notepad++ on the selected file
+7. F12 runs notepad or notepad++ on the selected file. Confgigure via Winfile.ini[Settings]EditorPath
 8. moved the ini file location to `%AppData%\Roaming\Microsoft\WinFile`
 9. File.Search can include a date which limits the files returned to those after the date provided;
 the output is also sorted by the date instead of by the name
@@ -100,8 +100,8 @@ the output is also sorted by the date instead of by the name
 11. `ctrl+K` starts a command shell (ConEmu if installed) in the current directory; `shift+ctrl+K`
 starts an elevated command shell (`cmd.exe` only)
 12. File.Goto (`ctrl+G`) enables one to type a few words of a path and get a list of directories;
-selecting one changes to that directory.  Only drive c: is indexed.
-13. UI shows reparse points (e.g., Junction points) as such
+selecting one changes to that directory.  Default = c:\. Confgigure via Winfile.ini[Settings]CachedPath
+13. UI shows reparse points (e.g., Junction points and Symbolic Links) as such
 14. added simple forward / back navigation (probably needs to be improved)
 15. View command has a new option to sort by date forward (oldest on top);
 normal date sorting is newest on top

--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -655,7 +655,23 @@ BuildDirectoryTreeBagOValues(PVOID pv)
 
 	SendMessage(hwndStatus, SB_SETTEXT, 2, (LPARAM)TEXT("BUILDING GOTO CACHE"));
 
-	if (BuildDirectoryBagOValues(pBagNew, pNodes, TEXT("c:\\"), nullptr, scanEpocNew))
+   // Read pathes, which shall be cached from winfile.ini
+   TCHAR szCached[MAX_PATH];
+   GetPrivateProfileString(szSettings, szCachedPath, TEXT("c:\\"), szCached, MAX_PATH, szTheINIFile);
+
+   // Iterate through ; seperated list of to be cached pathes
+   BOOL     buildBag{ FALSE };
+   WCHAR 	seps[]{ L";" };
+   PWCHAR   token{ nullptr };
+   PWCHAR	firsttoken = wcstok_s(szCached, seps, &token);
+   if (firsttoken)
+      buildBag = BuildDirectoryBagOValues(pBagNew, pNodes, firsttoken, nullptr, scanEpocNew);
+
+   while (PWCHAR nexttoken = wcstok_s(NULL, seps, &token))
+      buildBag |= BuildDirectoryBagOValues(pBagNew, pNodes, nexttoken, nullptr, scanEpocNew);
+
+	// If at least one cache location has been read successfully, build the bag
+   if (buildBag)
 	{
 		pBagNew->Sort();
 

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -1179,6 +1179,7 @@ Extern TCHAR        szDisableVisualStyles[] EQ( TEXT("DisableVisualStyles") );
 Extern TCHAR        szUILanguage[]          EQ( TEXT("UILanguage") );
 Extern TCHAR        szEditorPath[]          EQ( TEXT("EditorPath"));
 Extern TCHAR        szMirrorContent[]       EQ( TEXT("MirrorContent") );
+Extern TCHAR        szCachedPath[]          EQ( TEXT("CachedPath"));
 
 Extern TCHAR        szMinOnRun[]            EQ( TEXT("MinOnRun") );
 Extern TCHAR        szIndexOnLaunch[]       EQ( TEXT("IndexOnLaunch") );


### PR DESCRIPTION
The pathes, which shall be cached for the Goto dialog can be configured via WinFile.ini

e.g.
CachedPath=c:\;d:\

Since I am not a native speaker, do you have a better word for 'CachedPath'? 