### PR TITLE
Allow right arrow expand without proactively recursively enumerating

### DIFF
--- a/src/treectl.c
+++ b/src/treectl.c
@@ -786,7 +786,7 @@ ReadDirLevel(
                  bResult = FALSE;
                  goto DONE;
               }
-          } else /* if (dwView & VIEW_PLUSES)  ALWAYS DO THIS for arrow-driven expand/collapse */ {
+          } else if (dwView & VIEW_PLUSES) {
              ScanDirLevel(pNode, szPath, dwAttribs & ATTR_HS);
           }
       }
@@ -2953,11 +2953,11 @@ UpdateSelection:
       case VK_LEFT:
          TypeAheadString('\0', NULL);
 
-		 // if node is expanded and no control key, just collapse
-		 if ((pNode->wFlags & TF_EXPANDED) != 0 && GetKeyState(VK_CONTROL) >= 0) {
-			 CollapseLevel(hwndLB, pNode, i);
-			 return(i);
-		 }
+         // if node is expanded and no control key, just collapse
+         if ((pNode->wFlags & TF_EXPANDED) != 0 && GetKeyState(VK_CONTROL) >= 0) {
+            CollapseLevel(hwndLB, pNode, i);
+            return(i);
+         }
 
          while (SendMessage(hwndLB, LB_GETTEXT, --i, (LPARAM)&pNodeNext) != LB_ERR) {
             if (pNodeNext == pNode->pParent)
@@ -2968,13 +2968,13 @@ UpdateSelection:
       case VK_RIGHT:
          TypeAheadString('\0', NULL);
 
-		 // if node has children (due to ScanDirLevel happening often) and not expanded and no control key, just expand
-		 if ((pNode->wFlags & TF_HASCHILDREN) != 0 && !(pNode->wFlags & TF_EXPANDED) && GetKeyState(VK_CONTROL) >= 0) {
-			 ExpandLevel(hwnd, 0, i, szPath);
-			 return(i);
-		 }
+         // if node is not expanded and no control key, just expand
+         if (!(pNode->wFlags & TF_EXPANDED) && GetKeyState(VK_CONTROL) >= 0) {
+            ExpandLevel(hwnd, 0, i, szPath);
+            return(i);
+         }
 
-		 if ((SendMessage(hwndLB, LB_GETTEXT, i+1, (LPARAM)&pNodeNext) == LB_ERR)
+         if ((SendMessage(hwndLB, LB_GETTEXT, i+1, (LPARAM)&pNodeNext) == LB_ERR)
             || (pNodeNext->pParent != pNode)) {
             goto SameSelection;
          }


### PR DESCRIPTION
This is to fix #273 .  Based on the description that this occurs when "Directories Read" is displayed in the status bar and is gradually incrementing, this delay seems highly likely to be caused by `ScanDirLevel`.  This change removes that call unless VIEW_PLUSES is set, and updates the right arrow code to not depend on it.

When looking at the right arrow code, compare to how double click works.  This is handled in `OpenOrEditSelection`, which sends `TC_TOGGLELEVEL` back to `TreeControlWndProc`, which checks the current state, and if it's not expanded, sends `TC_EXPANDLEVEL` to itself.  The code in `TC_EXPANDLEVEL` calls `ExpandLevel` unconditionally whether there is anything known to be under the level or not.  So I believe/assert this must be safe/correct for right arrows too.

Regardless of this change, right arrow into a tree with contents will trigger an enumerate; the previous logic avoids this enumerate if the tree is known to contain nothing, but that means it enumerates the subtree upfront instead.  So I'd also assert that this change means fewer enumerates in total, but it can change when they occur.