### PR TITLE
When junctions are hidden, also hide from left pane

### DIFF
--- a/src/lfn.c
+++ b/src/lfn.c
@@ -92,8 +92,10 @@ WFFindFirst(
    lpFind->nSpaceLeft = MAXPATHLEN-nLen-1;
 
    if (lpFind->hFindFile != INVALID_HANDLE_VALUE) {
+      DWORD compareAttributes;
+      compareAttributes = lpFind->fd.dwFileAttributes & ATTR_USED;
       lpFind->dwAttrFilter = dwAttrFilter;
-      if ((~dwAttrFilter & lpFind->fd.dwFileAttributes) == 0L ||
+      if ((~dwAttrFilter & compareAttributes) == 0L ||
          WFFindNext(lpFind)) {
          return(TRUE);
       } else {

--- a/src/treectl.c
+++ b/src/treectl.c
@@ -166,6 +166,7 @@ ScanDirLevel(PDNODE pParentNode, LPTSTR szPath, DWORD view)
 {
   BOOL bFound;
   LFNDTA lfndta;
+  BOOL bExclude;
 
   /* Add '*.*' to the current path. */
   lstrcpy(szMessage, szPath);
@@ -178,9 +179,18 @@ ScanDirLevel(PDNODE pParentNode, LPTSTR szPath, DWORD view)
 
   while (bFound)
     {
+      /* Is this a junction and are those displayed? */
+      bExclude = FALSE;
+      if ((view & ATTR_JUNCTION) == 0 &&
+          (lfndta.fd.dwFileAttributes & ATTR_JUNCTION)) {
+
+          bExclude = TRUE;
+      }
+
       /* Is this not a '.' or '..' directory? */
       if (!ISDOTDIR(lfndta.fd.cFileName) &&
-         (lfndta.fd.dwFileAttributes & ATTR_DIR)) {
+         (lfndta.fd.dwFileAttributes & ATTR_DIR) &&
+         !bExclude) {
 
          pParentNode->wFlags |= TF_HASCHILDREN;
          bFound = FALSE;
@@ -663,6 +673,22 @@ ReadDirLevel(
       lstrcpy(szMessage, szPath);
 
       bFound = WFFindFirst(&lfndta, szMessage, dwAttribs);
+      if (bFound)
+      {
+          while (TRUE)
+          {
+              //  If it's a junction and we're not displaying those,
+              //  loop again for the next entry
+              if (lfndta.fd.dwFileAttributes & ATTR_JUNCTION &&
+                  (!(dwAttribs & ATTR_JUNCTION)))
+              {
+
+                  bFound = WFFindNext(&lfndta); // get it from dos
+                  continue;
+              }
+              break;
+          }
+      }
    }
 
    // for net drive case where we can't actually see what is in these
@@ -787,7 +813,7 @@ ReadDirLevel(
                  goto DONE;
               }
           } else if (dwView & VIEW_PLUSES) {
-             ScanDirLevel(pNode, szPath, dwAttribs & ATTR_HS);
+             ScanDirLevel(pNode, szPath, dwAttribs & (ATTR_HS | ATTR_JUNCTION));
           }
       }
 
@@ -836,7 +862,22 @@ ReadDirLevel(
       }
       else
       {
-          bFound = WFFindNext(&lfndta); // get it from dos
+          while (TRUE)
+          {
+              bFound = WFFindNext(&lfndta); // get it from dos
+              if (bFound)
+              {
+                  //  If it's a junction and we're not displaying those,
+                  //  loop again for the next entry
+                  if (lfndta.fd.dwFileAttributes & ATTR_JUNCTION &&
+                      (!(dwAttribs & ATTR_JUNCTION)))
+                  {
+
+                      continue;
+                  }
+              }
+              break;
+          }
       }
   }
 
@@ -932,7 +973,7 @@ StealTreeData(
    // we need to match on these attributes as well as the name
    //
    dwView    = GetWindowLongPtr(GetParent(hwndTC), GWL_VIEW) & VIEW_PLUSES;
-   dwAttribs = GetWindowLongPtr(GetParent(hwndTC), GWL_ATTRIBS) & ATTR_HS;
+   dwAttribs = GetWindowLongPtr(GetParent(hwndTC), GWL_ATTRIBS) & (ATTR_HS | ATTR_JUNCTION);
 
    //
    // get the dir of this new window for compare below
@@ -948,7 +989,7 @@ StealTreeData(
          (hwndT != hwndTC) &&
          !GetWindowLongPtr(hwndT, GWL_READLEVEL) &&
          (dwView  == (DWORD)(GetWindowLongPtr(hwndSrc, GWL_VIEW) & VIEW_PLUSES)) &&
-         (dwAttribs == (DWORD)(GetWindowLongPtr(hwndSrc, GWL_ATTRIBS) & ATTR_HS))) {
+         (dwAttribs == (DWORD)(GetWindowLongPtr(hwndSrc, GWL_ATTRIBS) & (ATTR_HS | ATTR_JUNCTION)))) {
 
          SendMessage(hwndSrc, FS_GETDIRECTORY, COUNTOF(szSrc), (LPARAM)szSrc);
          StripBackslash(szSrc);
@@ -1084,7 +1125,8 @@ FillTreeListbox(HWND hwndTC,
 
       if (pNode) {
 
-         dwAttribs = ATTR_DIR | (GetWindowLongPtr(GetParent(hwndTC), GWL_ATTRIBS) & ATTR_HS);
+         dwAttribs = GetWindowLongPtr(GetParent(hwndTC), GWL_ATTRIBS);
+         dwAttribs = ATTR_DIR | (dwAttribs & (ATTR_HS | ATTR_JUNCTION));
          cNodes = 0;
          bCancelTree = FALSE;
 
@@ -1155,7 +1197,8 @@ FillOutTreeList(HWND hwndTC,
 
 	SendMessage(hwndLB, WM_SETREDRAW, FALSE, 0L);
 
-	dwAttribs = ATTR_DIR | (GetWindowLongPtr(GetParent(hwndTC), GWL_ATTRIBS) & ATTR_HS);
+	dwAttribs = GetWindowLongPtr(GetParent(hwndTC), GWL_ATTRIBS);
+	dwAttribs = ATTR_DIR | (dwAttribs & (ATTR_HS | ATTR_JUNCTION));
 
 	// get path to node that already exists in tree; will start reading from there
 	GetTreePath(pNode, szExists);
@@ -1861,6 +1904,7 @@ ExpandLevel(HWND hWnd, WPARAM wParam, INT nIndex, LPTSTR szPath)
   INT iExpandInView;
   INT iCurrentIndex;
   RECT rc;
+  DWORD dwAttribs;
 
   //
   // Don't do anything while the tree is being built.
@@ -1916,8 +1960,9 @@ ExpandLevel(HWND hWnd, WPARAM wParam, INT nIndex, LPTSTR szPath)
 
   if (IsTheDiskReallyThere(hWnd, szPath, FUNC_EXPAND, FALSE))
   {
-     ReadDirLevel(hWnd, pNode, szPath, pNode->nLevels + 1, nIndex,
-        (DWORD)(ATTR_DIR | (GetWindowLongPtr(GetParent(hWnd), GWL_ATTRIBS) & ATTR_HS)),
+     dwAttribs = GetWindowLongPtr(GetParent(hWnd), GWL_ATTRIBS);
+     dwAttribs = ATTR_DIR | (dwAttribs & (ATTR_HS | ATTR_JUNCTION));
+     ReadDirLevel(hWnd, pNode, szPath, pNode->nLevels + 1, nIndex, dwAttribs,
         (BOOL)wParam, NULL, IS_PARTIALSORT(DRIVEID(szPath)));
   }
 
@@ -2355,7 +2400,7 @@ TreeControlWndProc(
             lstrcpy(szPath, (LPTSTR)lParam);
             ScanDirLevel( (PDNODE)pNodeT,
                           szPath,
-                          (GetWindowLongPtr(hwndParent, GWL_ATTRIBS) & ATTR_HS));
+                          (GetWindowLongPtr(hwndParent, GWL_ATTRIBS) & (ATTR_HS | ATTR_JUNCTION)));
 
             //
             // Invalidate the window so the plus gets drawn if needed

--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -906,25 +906,7 @@ Fail:
       //
       // be safe, zero unused DOS dta bits
       //
-      lfndta.fd.dwFileAttributes &= ATTR_USED;
-
-      //
-      // if reparse point, figure out whether it is a junction point
-	  if (lfndta.fd.dwFileAttributes & ATTR_REPARSE_POINT)
-      {
-          DWORD tag = DecodeReparsePoint(szPath, pName, szLinkDest, COUNTOF(szLinkDest));
-
-          if (tag == IO_REPARSE_TAG_MOUNT_POINT)
-              lfndta.fd.dwFileAttributes |= ATTR_JUNCTION;
-
-          else if (tag == IO_REPARSE_TAG_SYMLINK)
-              lfndta.fd.dwFileAttributes |= ATTR_SYMBOLIC;
-
-          else
-          {
-              // DebugBreak();
-          }
-      }
+      lfndta.fd.dwFileAttributes &= (ATTR_USED | ATTR_JUNCTION | ATTR_SYMBOLIC);
 
 	  //
       // filter unwanted stuff here based on current view settings


### PR DESCRIPTION
This is to fix #268 .  Although it's not what the title says, looking closer at the screenshots, the concern is around seeing junctions in the left pane (which the user does not have access to), even though the setting for "Show Junction Points" is disabled.

This change leverages `dwReserved0` to identify the reparse tag, which is [now documented behavior](https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-win32_find_dataw) but has existed since reparse points were added in Windows 2000.  I followed the pattern of having the caller filter junctions, which is not optimal - with `dwReserved0` it should be possible to use `dwAttrFilter` for Junctions too, but that requires carefully scrubbing the code to ensure it's propagated.  Most of this change is about propagating it in the left hand pane enumerate.

Also, I'm not stepping back from [my comment](https://github.com/microsoft/winfile/issues/268#issuecomment-1021917860) that the "real" fix is to not have a race condition enumerating the left pane.  That change seems large and complex enough that it's likely to introduce bugs and unlikely to be accepted.  But the advantage of doing it is to eliminate "network hangs" by doing file system operations on the UI thread, which the current code can't achieve.