### PR TITLE
Display child windows with sunken borders for purely cosmetic reasons

### DIFF
--- a/src/wftree.c
+++ b/src/wftree.c
@@ -535,6 +535,7 @@ TreeWndProc(
 
             INT dxSplit;
             DRIVE drive;
+            DWORD dwNewExStyle;
             WCHAR szPath[2 * MAXFILENAMELEN];
 
             //
@@ -563,6 +564,19 @@ TreeWndProc(
 
             SetWindowLongPtr(hwnd, GWL_VOLNAME, 0L);
             SetWindowLongPtr(hwnd, GWL_PATHLEN, 0L);
+
+            //
+            // Add a sunken border to the window
+            //
+            dwNewExStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
+            dwNewExStyle = dwNewExStyle | WS_EX_CLIENTEDGE;
+            SetWindowLong(hwnd, GWL_EXSTYLE, dwNewExStyle);
+
+            //
+            // Refresh its frame so the child windows below are created
+            // in the correct place now the border is in place
+            //
+            SetWindowPos(hwnd, NULL, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOCOPYBITS);
 
             if (!ResizeSplit(hwnd, dxSplit))
                return -1;


### PR DESCRIPTION
This is to fix #242 .  Note this is cosmetic and subjective, so it's completely fair if people think this not a change we want to make, although if there's a concern about the visual change, I think we should close #242 to clearly indicate this is not something to pursue.  Note the visual change depends a little on the Windows version; I agree with the screenshot in 242 that this works better with the "classic" UI, although it's less clear on a more modern UI that it's visually superior.

In terms of implementation, note that the code has a frame window; within that there's a child which is the MDIClient; and within that are individual windows.  Those windows are created via `WM_MDICREATE` which doesn't specify extended styles.  So this change works by setting extended styles during create, then forcing a recalculation of the client area (since the nonclient area adds an extra pixel by setting this flag.)