### PR TITLE
Do not follow Reparse Points during deletion and copy

### DIFF
--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -1445,6 +1445,7 @@ GetNextPair(PCOPYROOT pcr, LPTSTR pFrom,
             // Check if we should skip an entry because it was e.g. an reparse point
             if (pDTA->fd.dwFileAttributes & ATTR_SYMBOLIC) {
                pDTA->fd.dwFileAttributes &= ~ATTR_SYMBOLIC;
+               RemoveLast(pcr->szDest);
                goto SkipThisFile;
             }
 

--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -1442,6 +1442,12 @@ GetNextPair(PCOPYROOT pcr, LPTSTR pFrom,
             if (pcr->bFastMove)
                goto FastMoveSkipDir;
 #endif
+            // Check if we should skip an entry because it was e.g. an reparse point
+            if (pDTA->fd.dwFileAttributes & ATTR_SYMBOLIC) {
+               pDTA->fd.dwFileAttributes &= ~ATTR_SYMBOLIC;
+               goto SkipThisFile;
+            }
+
             pcr->cDepth++;
             pDTA++;
 
@@ -1685,7 +1691,14 @@ SearchStartFail:
                   goto ReturnPair;
                }
 
-               //
+               // Skip reparse points
+               if (dwFunc == FUNC_DELETE && pDTA->fd.dwFileAttributes & ATTR_REPARSE_POINT) {
+                  pcr->fRecurse = FALSE;
+                  dwOp = OPER_RMDIR;
+                  goto ReturnPair;
+               }
+
+			   //
                // Directory: operation is recursive.
                //
                pcr->fRecurse = TRUE;
@@ -2723,7 +2736,16 @@ SkipMKDir:
                goto CancelWholeOperation;
             }
 #endif
-            break;
+            
+            // Check if we came a long a reparse point
+            dwAttr = GetFileAttributes(szSource);
+            if (dwAttr & ATTR_REPARSE_POINT) {
+               // Yes, lets unlink it, but signal GetNextPair() that it should not crawl down the reparse point.
+               // We are using ATTR_SYMBOLIC to flag Junctions and Symbolic Links here
+               ret = RMDir(szSource);
+               pDTA->fd.dwFileAttributes |= ATTR_SYMBOLIC;
+            }
+			break;
 
          case IDNO:
          case IDCANCEL:

--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -1445,7 +1445,8 @@ GetNextPair(PCOPYROOT pcr, LPTSTR pFrom,
             // Check if we should skip an entry because it was e.g. an reparse point
             if (pDTA->fd.dwFileAttributes & ( ATTR_SYMBOLIC | ATTR_JUNCTION) ) {
                RemoveLast(pcr->szDest);
-               goto SkipThisFile;
+               dwOp = OPER_RMDIR;
+               goto ReturnPair;
             }
 
             pcr->cDepth++;
@@ -1691,7 +1692,7 @@ SearchStartFail:
                   goto ReturnPair;
                }
 
-               // Skip reparse points
+               // Return reparse point and delete it via OPER_RMDIR
                if (dwFunc == FUNC_DELETE && pDTA->fd.dwFileAttributes & (ATTR_SYMBOLIC | ATTR_JUNCTION)) {
                   pcr->fRecurse = FALSE;
                   dwOp = OPER_RMDIR;
@@ -2736,12 +2737,6 @@ SkipMKDir:
                goto CancelWholeOperation;
             }
 #endif
-            
-            // Check if we came a long a junction or symbolic link
-            if (pDTA->fd.dwFileAttributes & (ATTR_SYMBOLIC | ATTR_JUNCTION)) {
-               // Just unlink it
-               ret = RMDir(szSource);
-            }
 			break;
 
          case IDNO:


### PR DESCRIPTION
### Problem
Winfile follows reparse points during deletion and thus deletes linked content, which is not wanted. Currently there is no way of simply unlinking a reparse point. Explorer is aware of this. 
I would say this is a critical problem in Winfile, because it really deletes things, which you don't want to be deleted

### How to test
Download ln.exe from https://schinagl.priv.at/nt/ln/ln64.zip and place it in the same directory as the below .bat file
Start [TestDeleteReparsePoint.bat](https://github.com/microsoft/winfile/files/8055166/TestDeleteReparsePoint.zip) from an administrative command prompt (or grant yourself the right to create symbolic links) in your e.g. temp directory.

It builds a structure like 
```
├───1
│   ├───iLib
│   │   ├───inc
│   │   └───src
│   ├───iLib_symlink (-> x:\sl\iLib )
│   │   ├───inc
│   │   └───src
│   └───zzz
└───sl
    ├───iLib
    │   ├───inc
    │   └───src
    ├───iLib_symlink (-> x:\sl\iLib )
    │   ├───inc
    │   └───src
    └───zzz
```
	
The two symbolic links point to x:\sl\iLib. One can test two main uses-cases

**Unlinking a symbolic link:**
In Winfile navigate to x:\sl\iLib\iLib_symlink and delete it. This will simply unlink the
symbolic link and does no harm to x:\sl\iLib as the original version does

**Unlink as part of recursive deletion**
In Winfile navigate to x:\1 and delete it. x:\1\iLib_symlink will be unlinked during the recursive operation

In both cases x:\sl\iLib keeps its content

### Comments to the code
Basically there are two changes
* wfcopy.c:GetNextPair() can now skip directories by setting ATTR_SYMBOLIC link in its fd.dwFileAttributes. This change is needed during recursive deletion.
* wfcopy.c:1695 This is needed if the selected item is a reparse point