### PR TITLE
Do not follow Reparse Points during copy

### DIFF
--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -2684,6 +2684,10 @@ DoMkDir:
 
          // set attributes of new directory to those of the source
 
+         // If it was an reparse point don't copy its children, because they are already there
+         if (pDTA->fd.dwFileAttributes & ATTR_REPARSE_POINT)
+            pDTA->fd.dwFileAttributes |= ATTR_SYMBOLIC;
+
 #ifdef NETCHECK
 SkipMKDir:
 #endif


### PR DESCRIPTION
### Problem
Winfile follows Reparse Points during copy and tries to copy files more than once, which results in error message, that the files already exist

### How to test
Download ln.exe from https://schinagl.priv.at/nt/ln/ln64.zip and place it in the same directory as the below .bat file.
Start [TestCopyReparsePoint.bat](https://github.com/microsoft/winfile/files/8073696/TestCopyReparsePoint.zip) from an administrative command prompt (or grant yourself the right to create symbolic links) in your e.g. temp directory.

It builds a structure like
```
├───1
└───sl
    ├───iLib
    │   ├───inc
    │   └───src
    ├───iLib_symlink
    │   ├───inc
    │   └───src
    └───zzz
```

Navigate to x:\sl in Winfile and copy it e.g. via Drag and CTRL to x:\1. You will receive no errors opposite to the original version, which tries to copy all files below x:\sl\iLib_symlink onto itself when it has copied x:\q\sl\iLib_Symlink to its destination.

### Comments to the code
Basically there is one change and it builds up on the 'skip' feature in GetNetxPair() which was introduced with #303.
In general Winfile implements the simplest of all Reparse Point copy strategies, which I called the 'Splice' method. See also the [explanation of Splice](https://schinagl.priv.at/nt/hardlinkshellext/hardlinkshellext.html#splice) in the LinkShellExtension Docu. 

Winfile does the 'Splice' pattern also for inner and outer reparse points. So this will only work for absolute symbolic links. Relaive symbolic links will be copied but point to 'something'. This can not be solved for Winfile, because it needs more sophisticated symlink resolving.
