### PR TITLE
Left Pane implodes on dead Reparse Points

### DIFF
--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -748,10 +748,7 @@ InvalidDirectory:
             if (hwndTree=HasTreeWindow(hwnd)) {
 
                // Check if it is a Reparse Point
-               lpTemp[0] = '\0';
-               DWORD attr = GetFileAttributes(szPath);
-               lpTemp[0] = CHAR_BACKSLASH;
-               if (attr & ATTR_REPARSE_POINT) {
+               if (dwAttribs & (ATTR_JUNCTION | ATTR_SYMBOLIC)) {
                   // For dead Reparse Points just tell that the directory could not be read
                   break;
                } else {

--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -748,7 +748,10 @@ InvalidDirectory:
             if (hwndTree=HasTreeWindow(hwnd)) {
 
                // Check if it is a Reparse Point
-               if (dwAttribs & (ATTR_JUNCTION | ATTR_SYMBOLIC)) {
+               lpTemp[0] = '\0';
+               DWORD attr = GetFileAttributes(szPath);
+               lpTemp[0] = CHAR_BACKSLASH;
+               if (attr & ATTR_REPARSE_POINT) {
                   // For dead Reparse Points just tell that the directory could not be read
                   break;
                } else {

--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -753,7 +753,6 @@ InvalidDirectory:
                lpTemp[0] = CHAR_BACKSLASH;
                if (attr & ATTR_REPARSE_POINT) {
                   // For dead Reparse Points just tell that the directory could not be read
-                  iError = IDS_COPYERROR + FUNC_EXPAND;
                   break;
                } else {
                   //

--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -747,17 +747,27 @@ InvalidDirectory:
 
             if (hwndTree=HasTreeWindow(hwnd)) {
 
-               //
-               // If we changed dirs, and there is a tree window, set the
-               // dir to the root and collapse it
-               // Note that lpTemp-szPath>2, szPath[3] is not in the file spec
-               //
-               szPath[3] = CHAR_NULL;
-               SendMessage(hwndTree, TC_SETDIRECTORY, 0, (LPARAM)szPath);
-               SendMessage(hwndTree, TC_COLLAPSELEVEL, 0, 0L);
+               // Check if it is a Reparse Point
+               lpTemp[0] = '\0';
+               DWORD attr = GetFileAttributes(szPath);
+               lpTemp[0] = CHAR_BACKSLASH;
+               if (attr & ATTR_REPARSE_POINT) {
+                  // For dead Reparse Points just tell that the directory could not be read
+                  iError = IDS_COPYERROR + FUNC_EXPAND;
+                  break;
+               } else {
+                  //
+                  // If we changed dirs, and there is a tree window, set the
+                  // dir to the root and collapse it
+                  // Note that lpTemp-szPath>2, szPath[3] is not in the file spec
+                  //
+                  szPath[3] = CHAR_NULL;
+                  SendMessage(hwndTree, TC_SETDIRECTORY, 0, (LPARAM)szPath);
+                  SendMessage(hwndTree, TC_COLLAPSELEVEL, 0, 0L);
 Fail:
-               MemDelete(lpStart);
-               return NULL;
+                  MemDelete(lpStart);
+                  return NULL;
+               }
             }
 
             lstrcpy(szPath+3, lpTemp+1);


### PR DESCRIPTION
### Problem
The left pane implodes to the root drive if one clicks on a dead Reparse Point

### How to test
Download ln.exe from https://schinagl.priv.at/nt/ln/ln64.zip and place it in the same directory as the below .bat file
Start [TestDeadReparseImplode.bat](https://github.com/microsoft/winfile/files/8102923/TestDeadReparseImplode.zip) from an administrative command prompt (or grant yourself the right to create symbolic links) in your e.g. temp directory.

It builds a structure like
```
└───dest
    └───sl
        ├───iLib_dead
        └───iLib_symlink

```
Navigate to x:\dest\sl and double click on iLib_symlink. The left pane does not implode to the root as the original version does.

### Comments to the code
There is one little change in CreateDTABlockWorker(), which deals with the failing WFFindFirst and checks if the item was a dead Reparse Point
