### PR TITLE
Incorporate PR feedback for link icon change

### DIFF
--- a/src/treectl.c
+++ b/src/treectl.c
@@ -1692,12 +1692,12 @@ TCWP_DrawItem(
 
             } else if (!(view & VIEW_PLUSES) || !(pNode->wFlags & TF_HASCHILDREN)) {
                if (bDrawSelected)  {
-                  if (pNode->dwAttribs & ATTR_REPARSE_POINT)
+                  if (pNode->dwAttribs & (ATTR_SYMBOLIC | ATTR_JUNCTION))
                      iBitmap = BM_IND_OPENREPARSE;
                   else
                      iBitmap = BM_IND_OPEN;
                } else {
-                  if (pNode->dwAttribs & ATTR_REPARSE_POINT)
+                  if (pNode->dwAttribs & (ATTR_SYMBOLIC | ATTR_JUNCTION))
                      iBitmap = BM_IND_CLOSEREPARSE;
                   else
                      iBitmap = BM_IND_CLOSE;

--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -916,7 +916,7 @@ Fail:
             iBitmap = BM_IND_CLOSEDFS;
          else
          {
-            if (lfndta.fd.dwFileAttributes & ATTR_REPARSE_POINT)
+            if (lfndta.fd.dwFileAttributes & (ATTR_SYMBOLIC | ATTR_JUNCTION))
                iBitmap = BM_IND_CLOSEREPARSE;
             else
                iBitmap = BM_IND_CLOSE;
@@ -928,7 +928,7 @@ Fail:
       } else if (pDoc) {
          iBitmap = BM_IND_DOC;
       } else {
-         if (lfndta.fd.dwFileAttributes & ATTR_REPARSE_POINT)
+         if (lfndta.fd.dwFileAttributes & (ATTR_SYMBOLIC | ATTR_JUNCTION))
             iBitmap = BM_IND_FILREPARSE;
          else
             iBitmap = BM_IND_FIL;

--- a/src/wfsearch.c
+++ b/src/wfsearch.c
@@ -308,7 +308,7 @@ MemoryError:
             lpxdta->dwAttrs |= ATTR_LOWERCASE;
 
          if (dwAttrs & ATTR_DIR) {
-            if (dwAttrs & ATTR_REPARSE_POINT)
+            if (dwAttrs & (ATTR_SYMBOLIC | ATTR_JUNCTION))
                iBitmap = BM_IND_CLOSEREPARSE;
             else
                iBitmap = BM_IND_CLOSE;


### PR DESCRIPTION
This is addressing the feedback in #304 :

1. Use ATTR_SYMBOLIC | ATTR_JUNCTION to test whether something is a link, since a reparse point is not always a link; it could be a virtual git file, store app, onedrive placeholder, all kinds of things;
2. Use braces around if conditions.  There was a commit for this in the original PR but it wasn't included in the merge.