### PR TITLE
One Level file '- Copy' pattern

### DIFF
--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -1803,7 +1803,10 @@ MergeNames:
             lstrcat(pToPath, L" - Copy");
             lstrcat(pcr->szDest, L" - Copy");
             break;
+
          default:
+            dwOp = OPER_ERROR;
+            *pdwError = DE_DESTSUBTREE;
             break;
          }
       } else {

--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -2433,11 +2433,11 @@ TRY_COPY_AGAIN:
 
             // Source and destination are exactly the same
             WCHAR szDestAlt[MAX_PATH + 2] = { 0 };
-            lstrcpy(szDestAlt, szDest);
+            WCHAR szExtension[MAX_PATH + 2] = { 0 };
+            LPTSTR pExt;
 
             // Lets try to apply the 'Copy' pattern, e.g. 'file.ext' -> 'file - Copy.ext'
-            WCHAR szExtension[MAX_PATH + 2] = { 0 };
-            LPTSTR pExt = PathFindExtension(szDestAlt);
+            pExt = PathFindExtension(szDestAlt);
             if (*pExt) {
                // Split of extension if available
                lstrcpy(szExtension, pExt);
@@ -2458,7 +2458,7 @@ TRY_COPY_AGAIN:
                lstrcpy(szDest, szDestAlt);
             } else {
                // If one already used this '- Copy' postfix, bail out. Just one level.
-               ret = DE_SAMEFILE;
+               ret = DE_RENAMREPLACE;
                goto ShowMessageBox;
             }
 

--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -1797,18 +1797,16 @@ MergeNames:
 
    if (dwOp == OPER_MKDIR) {
 
-      if (!_wcsicmp(pFrom, pToPath)) {
-         switch (dwFunc) {
-         case FUNC_COPY:
-            lstrcat(pToPath, L" - Copy");
-            lstrcat(pcr->szDest, L" - Copy");
-            break;
+      //
+      // For a directory copy to the same name, append the "- Copy" suffix
+      // to both the target of this operation, and the target directory for
+      // recursive operations.  Unlike the regular file case, this does not
+      // consider file name extensions, since it is specific to directories.
+      //
 
-         default:
-            dwOp = OPER_ERROR;
-            *pdwError = DE_DESTSUBTREE;
-            break;
-         }
+      if (dwFunc == FUNC_COPY && !_wcsicmp(pFrom, pToPath)) {
+         lstrcat(pToPath, L" - Copy");
+         lstrcat(pcr->szDest, L" - Copy");
       } else {
          //
          // Make sure the new directory is not a subdir of the original...

--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -2448,9 +2448,6 @@ TRY_COPY_AGAIN:
             case FUNC_COPY:
                lstrcat(szDestAlt, L" - Copy");
                break;
-            
-            default:
-               break;
             }
 
             lstrcat(szDestAlt, szExtension);

--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -778,7 +778,7 @@ DirWndProc(
       break;
 
    case WM_QUERYDROPOBJECT:
-
+   {
       // lParam LPDROPSTRUCT
       //
       // return values:
@@ -790,7 +790,7 @@ DirWndProc(
       //
       // Ensure that we are dropping on the client area of the listbox.
       //
-#define lpds ((LPDROPSTRUCT)lParam)
+      LPDROPSTRUCT lpds = (LPDROPSTRUCT)lParam;
 
       //
       // Ensure that we can accept the format.
@@ -806,7 +806,7 @@ DirWndProc(
           return TRUE;
       }
       return FALSE;
-#undef lpds
+   }
 
    case WM_SETFOCUS:
       {

--- a/src/wfdirsrc.c
+++ b/src/wfdirsrc.c
@@ -1043,7 +1043,7 @@ DSDropObject(
    //
    // Are we dropping onto ourselves? (i.e. a selected item in the
    // source listbox OR an unused area of the source listbox)  If
-   // so, don't do anything.
+   // so, apply the '- Copy' postfix for the copy operation
    //
    if (hwndHolder == lpds->hwndSource) {
       if ((dwSelSink == (DWORD)-1) || SendMessage(hwndLB, LB_GETSEL, dwSelSink, 0L)) {

--- a/src/wfdirsrc.c
+++ b/src/wfdirsrc.c
@@ -286,9 +286,9 @@ DSDragLoop(HWND hwndLB, WPARAM wParam, LPDROPSTRUCT lpds)
    hwndGlobalSink = lpds->hwndSink;
 
    //
-   // default to copy
+   // default to move
    //
-   bShowBitmap = TRUE;
+   bShowBitmap = FALSE;
 
    //
    // can't drop here
@@ -1046,8 +1046,16 @@ DSDropObject(
    // so, don't do anything.
    //
    if (hwndHolder == lpds->hwndSource) {
-      if ((dwSelSink == (DWORD)-1) || SendMessage(hwndLB, LB_GETSEL, dwSelSink, 0L))
-         return TRUE;
+      if ((dwSelSink == (DWORD)-1) || SendMessage(hwndLB, LB_GETSEL, dwSelSink, 0L)) {
+
+         // set the destination, assume move/copy case below (c:\foo\)
+         //
+         SendMessage(hwndHolder, FS_GETDIRECTORY, COUNTOF(szTemp), (LPARAM)szTemp);
+
+         if (fShowSourceBitmaps == FALSE)
+            return TRUE;
+         goto DirMoveCopy;
+      }
    }
 
    //

--- a/src/wfdirsrc.c
+++ b/src/wfdirsrc.c
@@ -1041,21 +1041,15 @@ DSDropObject(
    dwSelSink = lpds->dwControlData;
 
    //
-   // Are we dropping onto ourselves? (i.e. a selected item in the
-   // source listbox OR an unused area of the source listbox)  If
-   // so, apply the '- Copy' postfix for the copy operation
+   // Are we dropping onto ourselves? (i.e. moving a selected item in the
+   // source listbox OR an unused area of the source listbox).  If so,
+   // no-op the request.
    //
-   if (hwndHolder == lpds->hwndSource) {
-      if ((dwSelSink == (DWORD)-1) || SendMessage(hwndLB, LB_GETSEL, dwSelSink, 0L)) {
+   if (hwndHolder == lpds->hwndSource &&
+      fShowSourceBitmaps == FALSE &&
+      ((dwSelSink == (DWORD)-1) || SendMessage(hwndLB, LB_GETSEL, dwSelSink, 0L))) {
 
-         // set the destination, assume move/copy case below (c:\foo\)
-         //
-         SendMessage(hwndHolder, FS_GETDIRECTORY, COUNTOF(szTemp), (LPARAM)szTemp);
-
-         if (fShowSourceBitmaps == FALSE)
-            return TRUE;
-         goto DirMoveCopy;
-      }
+      return TRUE;
    }
 
    //
@@ -1220,11 +1214,9 @@ NormalMoveCopy:
    //
    // Make sure that we don't move into same dir.
    //
-   if (GetWindowLongPtr(hwndHolder,
-                     GWL_LISTPARMS) == SendMessage(hwndMDIClient,
-                                                   WM_MDIGETACTIVE,
-                                                   0,
-                                                   0L)) {
+   if (fShowSourceBitmaps == FALSE &&
+      GetWindowLongPtr(hwndHolder, GWL_LISTPARMS) == SendMessage(hwndMDIClient, WM_MDIGETACTIVE, 0, 0L)) {
+
       return TRUE;
    }
 


### PR DESCRIPTION
### Motivation
One wants to create a copy of a file/directory in the very same directory. 
Dragging a file/directory onto the empty space in the file-pane does nothing currently.

### Improvements
With this change one can drag an already existing file/directory into the empty space of the file pane and an item with the ' - Copy' is created.
E.g. File.txt -> 'File - Copy.txt'
![FileCopyPattern](https://user-images.githubusercontent.com/7418603/159155523-e8fc3dfb-1501-467b-8874-070713040e6e.png)

Lets have a [live look
](https://user-images.githubusercontent.com/7418603/162826074-d0f83ec9-a622-48bb-b437-c7f10e33225b.mp4
)


### Comments on the Code
I starts in wfdirsr.c: 1049, where normally a drop on the same directory was blocked.
Enabling this only for 'copy' (fShowSourceBitmaps == TRUE) brings us to wfcopy.c, which is extended once for files and once for directories.


### Known Limitations
This PR intentionally only works in the same directory.
There is no Copy (n) algorithm implemented if applied multiple times on the same file.

### Dependencies
This one lives on its own, but if the Symlink/Hardlink one #312 will make it to the maintrunk, I will update this PR with a ' - Hardlink', '- Symlink' one.
I already have an aggregated version of all my changes under the _hermann branch.
