### PR TITLE
Symlink Icons are not shown after (un)compress

### DIFF
--- a/src/treectl.h
+++ b/src/treectl.h
@@ -34,4 +34,4 @@ typedef struct tagDNODE
 typedef DNODE *PDNODE;
 
 VOID GetTreePath(PDNODE pNode, register LPTSTR szDest);
-
+VOID SetNodeAttribs(PDNODE pNode, LPTSTR szPath);

--- a/src/wffile.c
+++ b/src/wffile.c
@@ -1715,7 +1715,6 @@ VOID RedrawAllTreeWindows()
     HWND hwnd, hwndTree, hwndLB;
     int cItems, ctr;
     PDNODE pNode;
-    DWORD dwAttribs;
     TCHAR szPathName[MAXPATHLEN * 2];
 
 
@@ -1737,13 +1736,10 @@ VOID RedrawAllTreeWindows()
                SendMessage(hwndLB, LB_GETTEXT, ctr, (LPARAM)&pNode);
 
                //
-               //  Set the attributes for this directory.
+               //  Set the attributes for this directory/junction/symlink.
                //
                GetTreePath(pNode, szPathName);
-               if ((dwAttribs = GetFileAttributes(szPathName)) != INVALID_FILE_ATTRIBUTES)
-               {
-                   pNode->dwAttribs = dwAttribs;
-               }
+               SetNodeAttribs(pNode, szPathName);
            }
 
            InvalidateRect(hwndLB, NULL, FALSE);


### PR DESCRIPTION
### Problem
In the aftermath of #308 I stumbled about one detail we missed:
After (un)compress on a symbolic link the symlink icon is not shown anymore.

### How to test
Download ln.exe from https://schinagl.priv.at/nt/ln/ln64.zip and place it in the same directory as the below .bat file.
Start [TestCopyReparsePoint.bat](https://github.com/microsoft/winfile/files/8430378/TestCopyReparsePoint.zip)  from an administrative command prompt in your e.g. temp directory. 

It builds a structure like
```
├───1
└───sl
    ├───iLib
    │   ├───inc
    │   └───src
    ├───iLib_symlink
    │   ├───inc
    │   └───src
    └───zzz
```

Select sl/iLib_symlink and choose from the menu File/(Un)Compress. The symlink icon of sl/iLib_symlink is shown properly contrary to the original. 

### Comments on the code
There are two locations in the source where the attributes are fetched directly via GetFileAttributes() and thus bypass WFFind{First|Next} extended in #297
1. treectl.c/InsertDirectory()
2. wffile.c/RedrawAllTreeWindows()

The topic 1. was handled in #308 as a byproduct, but 2. is addressed in this PR. 
Anyhow, the fix is simple and introduces a helper function SetNodeAttribs(), which is called from 1) and 2)
