### PR TITLE
Wrong position of selection after copy

### DIFF
--- a/src/treectl.c
+++ b/src/treectl.c
@@ -2452,15 +2452,6 @@ TreeControlWndProc(
             }
          }
 
-         //
-         // if we are inserting before or at the current selection
-         // push the current selection down
-         //
-         nIndex = (INT)SendMessage(hwndLB, LB_GETCURSEL, 0, 0L);
-         if ((INT)LOWORD(dwTemp) <= nIndex) {
-            SendMessage(hwndLB, LB_SETCURSEL, nIndex + 1, 0L);
-         }
-
          break;
 
       case FSC_RMDIR:


### PR DESCRIPTION
### Problem
When copying a tree above a selection the selection is way too below after the copy 
See [this short video](https://user-images.githubusercontent.com/7418603/163217428-fbf7e5cb-6cde-4467-b36a-593def056ce8.mp4)

The selection after copy is on 'IterateLPXDTA' which is wrong. It should be 'sl'. I checked a one year old version of Winfile and it is also there. So no side-effect of recent changes

### How to test
Download ln.exe from https://schinagl.priv.at/nt/ln/ln64.zip and place it in the same directory as the below .bat file.
Start [TestCopyReparsePoint.bat](https://github.com/microsoft/winfile/files/8430378/TestCopyReparsePoint.zip)  from an administrative command prompt in your e.g. temp directory.

It builds a structure like
```
├───1
└───sl
    ├───iLib
    │   ├───inc
    │   └───src
    ├───iLib_symlink
    │   ├───inc
    │   └───src
    └───zzz
```

Select sl/iLib_symlink and copy to 1/ and check the location after copy. 
It should [look like this](https://user-images.githubusercontent.com/7418603/163217725-2e975350-00f4-40e3-a3df-c480cf30e614.mp4)

### Comments on the code
It seems that there is code in treeCtl.c:~2470 which is superfluous, because some code else already does the repositioning after copy

