### PR TITLE
Netshare/NetUnShare Button always grayed out

### DIFF
--- a/src/res.h
+++ b/src/res.h
@@ -575,7 +575,7 @@
 #define IDS_DISCONNECT        (MS_EXTRA+1)
 #define IDS_CONNECTIONS       (MS_EXTRA+2)
 #define IDS_SHAREAS           (MS_EXTRA+3)
-#define IDS_STOPSHARE         (MS_EXTRA+4)
+#define IDS_STOPSHARE         (MS_EXTRA+4)  // IDS_STOPSHARE not used anymore, because there is no way to open then 'Stop Share Dialog' with W7/10/11
 #define IDS_SHARES            (MS_EXTRA+5)
 #define IDS_UNDELETE          (MS_EXTRA+6)
 #define IDS_NEWWINONCONNECT   (MS_EXTRA+7)

--- a/src/tbar.c
+++ b/src/tbar.c
@@ -58,7 +58,8 @@ static TBBUTTON tbButtons[] = {
   { 1, IDM_DISCONNECT , TBSTATE_ENABLED, TBSTYLE_BUTTON, 0 },
   { 0, 0              , TBSTATE_ENABLED, TBSTYLE_SEP   , 0 },
   { 2, IDM_SHAREAS    , TBSTATE_ENABLED, TBSTYLE_BUTTON, 0 },
-  { 3, IDM_STOPSHARE  , TBSTATE_ENABLED, TBSTYLE_BUTTON, 0 },
+// IDM_STOPSHARE not shown anymore, because there is no way to open then 'Stop Share Dialog' with W7/10/11
+//  { 3, IDM_STOPSHARE  , TBSTATE_ENABLED, TBSTYLE_BUTTON, 0 },
   { 0, 0              , TBSTATE_ENABLED, TBSTYLE_SEP   , 0 },
   { 4, IDM_VNAME      , TBSTATE_ENABLED, TBSTYLE_BUTTON, 0 },
   { 5, IDM_VDETAILS   , TBSTATE_ENABLED, TBSTYLE_BUTTON, 0 },

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -1667,9 +1667,12 @@ AppCommandProc(register DWORD id)
 
       if (lpfnShowShareFolderUI) {
          LPTSTR szDir;
-         BOOL bDir = FALSE;
+         HRESULT hr;
+         BOOL bDir;
+            
+         bDir = FALSE;
          szDir = GetSelection(1 | 4 | 16, &bDir);
-         HRESULT hr = ShowShareFolderUI(hwndFrame, szDir);
+         hr = ShowShareFolderUI(hwndFrame, szDir);
          if (hr != S_OK) {
             FormatError(TRUE, szMessage, COUNTOF(szMessage), ERROR_INVALID_SHARENAME);
 

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -1665,52 +1665,26 @@ AppCommandProc(register DWORD id)
       //
       WAITNET();
 
-      if (lpfnShareStop) {
+      if (lpfnShowShareFolderUI) {
+         LPTSTR szDir;
+         BOOL bDir = FALSE;
+         szDir = GetSelection(1 | 4 | 16, &bDir);
+         HRESULT hr = ShowShareFolderUI(hwndFrame, szDir);
+         if (hr != S_OK) {
+            FormatError(TRUE, szMessage, COUNTOF(szMessage), ERROR_INVALID_SHARENAME);
 
-         if (ret = ShareCreate(hwndFrame)) {
-
-            //
-            // Report error
-            // ret must the error code
-            //
-            goto DealWithNetError;
-
-         } else {
-
-            InvalidateAllNetTypes();
+            LoadString(hAppInstance, IDS_NETERR, szTitle, COUNTOF(szTitle));
+            MessageBox(hwndFrame, szMessage, szTitle, MB_OK | MB_ICONSTOP);
          }
+         InvalidateAllNetTypes();
       }
-
       break;
 
    case IDM_STOPSHARE:
 
       //
-      // Check to see if our delayed loading has finished.
+      // IDM_STOPSHARE not shown anymore, because there is no way to open then 'Stop Share Dialog' with W7/10/11 
       //
-      WAITNET();
-
-      if (lpfnShareStop) {
-
-         if (ret = ShareStop(hwndFrame)) {
-
-            //
-            // Report error
-            // ret must the error code
-            //
-
-DealWithNetError:
-
-            FormatError(TRUE, szMessage, COUNTOF(szMessage), ret);
-
-            LoadString(hAppInstance, IDS_NETERR, szTitle, COUNTOF(szTitle));
-            MessageBox(hwndFrame, szMessage, szTitle, MB_OK|MB_ICONSTOP);
-
-         } else {
-
-            InvalidateAllNetTypes();
-         }
-      }
       break;
 
 #if 0

--- a/src/wfinfo.c
+++ b/src/wfinfo.c
@@ -1736,17 +1736,17 @@ NetLoad(VOID)
 
    if (WNetStat(NS_SHAREDLG)) {
 
-      hNTLanman = LoadLibrary(NTLANMAN_DLL);
+      hNtshrui = LoadLibrary(NTSHRUI_DLL);
 
-      if (hNTLanman) {
+      if (hNtshrui) {
+         lpfnShowShareFolderUI = (PVOID)GetProcAddress(hNtshrui, "ShowShareFolderUI");
+         if (lpfnShowShareFolderUI)
+            PostMessage(hwndToolbar, TB_ENABLEBUTTON, IDM_SHAREAS, TRUE);
+         else {
 
-#define GET_PROC(x) \
-         if (!(lpfn##x = (PVOID) GetProcAddress(hNTLanman, NETWORK_##x))) \
-            goto Fail
-
-         GET_PROC(ShareCreate);
-         GET_PROC(ShareStop);
-#undef GET_PROC
+            PostMessage(hwndToolbar, TB_ENABLEBUTTON, IDM_SHAREAS, FALSE);
+            EnableMenuItem(GetMenu(hwndFrame), IDM_SHAREAS, MF_BYCOMMAND | MF_GRAYED);
+         }
 
          //
          // If bNetShareLoad is FALSE, then we know that the share stuff
@@ -1756,22 +1756,10 @@ NetLoad(VOID)
          //
          bNetShareLoad = TRUE;
 
-      } else {
-Fail:
-         //
-         // Disable the share buttons/menus
-         // Since WNetStat(NS_SHAREDLG) ret'd true, then we added the
-         // buttons.  Mistake.  Disable them now.
-         //
-         PostMessage(hwndToolbar, TB_ENABLEBUTTON, IDM_SHAREAS, FALSE);
          PostMessage(hwndToolbar, TB_ENABLEBUTTON, IDM_STOPSHARE, FALSE);
-
-         EnableMenuItem(GetMenu(hwndFrame), IDM_SHAREAS,
-            MF_BYCOMMAND | MF_GRAYED );
-
-         EnableMenuItem(GetMenu(hwndFrame), IDM_STOPSHARE,
-            MF_BYCOMMAND | MF_GRAYED );
+         EnableMenuItem(GetMenu(hwndFrame), IDM_STOPSHARE, MF_BYCOMMAND | MF_GRAYED);
       }
+
    }
 
    SetEvent(hEventNetLoad);

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -398,9 +398,9 @@ InitMenus()
       LoadString(hAppInstance, IDS_SHAREAS, szValue, COUNTOF(szValue));
       InsertMenu(hMenu, 8, MF_BYPOSITION | MF_STRING, IDM_SHAREAS, szValue);
 
-      LoadString(hAppInstance, IDS_STOPSHARE, szValue, COUNTOF(szValue));
-      InsertMenu(hMenu, 9, MF_BYPOSITION | MF_STRING, IDM_STOPSHARE, szValue);
-
+      // IDM_STOPSHARE not shown anymore, because there is no way to open then 'Stop Share Dialog' with W7/10/11 
+      // LoadString(hAppInstance, IDS_STOPSHARE, szValue, COUNTOF(szValue));
+      // InsertMenu(hMenu, 9, MF_BYPOSITION | MF_STRING, IDM_STOPSHARE, szValue);
    }
 
    //
@@ -1619,8 +1619,8 @@ FreeFileManager()
    if (hfmifsDll)
       FreeLibrary(hfmifsDll);
 
-   if (hNTLanman)
-      FreeLibrary(hNTLanman);
+   if (hNtshrui)
+      FreeLibrary(hNtshrui);
 
    if (hMPR)
       FreeLibrary(hMPR);

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -1038,7 +1038,6 @@ Extern DWORD (CALLBACK *lpfnWNetFormatNetworkNameW)(
                     DWORD    dwAveCharPerLine
                     );
 Extern DWORD (CALLBACK *lpfnShowShareFolderUI)(HWND, LPWSTR);
-Extern DWORD (CALLBACK *lpfnShareStop)(LPCWSTR, LPCWSTR, DWORD, HWND);
 
 #ifdef NETCHECK
 Extern DWORD (CALLBACK *lpfnWNetDirectoryNotifyW)(HWND, LPWSTR, DWORD);

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -1004,7 +1004,7 @@ BOOL LoadUxTheme(VOID);
 //----------------------------
 
 #define MPR_DLL      TEXT("mpr.dll")
-#define NTLANMAN_DLL TEXT("ntlanman.dll")
+#define NTSHRUI_DLL  TEXT("Ntshrui.dll")
 #define ACLEDIT_DLL  TEXT("acledit.dll")
 
 #define WAITNET()      WaitLoadEvent(TRUE)
@@ -1037,8 +1037,8 @@ Extern DWORD (CALLBACK *lpfnWNetFormatNetworkNameW)(
                     DWORD    dwFlags,
                     DWORD    dwAveCharPerLine
                     );
-Extern DWORD (CALLBACK *lpfnShareCreate)(HWND);
-Extern DWORD (CALLBACK *lpfnShareStop)(HWND);
+Extern DWORD (CALLBACK *lpfnShowShareFolderUI)(HWND, LPWSTR);
+Extern DWORD (CALLBACK *lpfnShareStop)(LPCWSTR, LPCWSTR, DWORD, HWND);
 
 #ifdef NETCHECK
 Extern DWORD (CALLBACK *lpfnWNetDirectoryNotifyW)(HWND, LPWSTR, DWORD);
@@ -1077,8 +1077,7 @@ Extern DWORD (CALLBACK *lpfnWNetDirectoryNotifyW)(HWND, LPWSTR, DWORD);
 #define WNetRestoreConnectionW     (*lpfnWNetRestoreConnectionW)
 #define WNetRestoreSingleConnectionW     (*lpfnWNetRestoreSingleConnectionW)
 #define WNetFormatNetworkNameW     (*lpfnWNetFormatNetworkNameW)
-#define ShareCreate                (*lpfnShareCreate)
-#define ShareStop                  (*lpfnShareStop)
+#define ShowShareFolderUI          (*lpfnShowShareFolderUI)
 
 #ifdef NETCHECK
 #define WNetDirectoryNotifyW       (*lpfnWNetDirectoryNotifyW)
@@ -1090,7 +1089,7 @@ Extern BOOL        bSecMenuDeleted;
 
 Extern HANDLE hVersion             EQ( NULL );
 Extern HANDLE hMPR                 EQ( NULL );
-Extern HANDLE hNTLanman            EQ( NULL );
+Extern HANDLE hNtshrui             EQ( NULL );
 Extern HANDLE hAcledit             EQ( NULL );
 
 


### PR DESCRIPTION
### Problem
Net Share not working. The share icon in the toolbar was always grayed out
![netsharegrayedout](https://user-images.githubusercontent.com/7418603/165337518-692a4d5f-9e11-45c3-93ad-607fb7535bd0.png)

### Comments on the code
Winfile used an API to share network resources from ntlanman.dll, which is not available anymore with Windows7/10
Changed it to use ShowShareFolderUI() from Ntshrui.dll. Works. 

Unsharing is the problem. How does one open this dialog
![StopShare](https://user-images.githubusercontent.com/7418603/165394332-5913ab71-7bc3-4a08-8773-a6b6ed450557.png)

Which is invoked through explorer via
![GiveAccess](https://user-images.githubusercontent.com/7418603/165394374-92b14340-1736-4f8d-b406-5b4948e060b9.png)

Any ideas? @craigwi , @malxau can you have a look behind the scenes on how explorer does this? Is it in Shell32.dll ? Or where is it?
I was not able to google this at first hand, maybe you are faster on this
