### PR TITLE
Search stops with error when it comes along a broken reparse point.

### DIFF
--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -710,7 +710,9 @@ CreateDTABlockWorker(
       //
       // Try again!  But first, see if the directory was invalid!
       //
-      if (ERROR_PATH_NOT_FOUND == lfndta.err) {
+      if (ERROR_PATH_NOT_FOUND == lfndta.err ||
+         ERROR_INVALID_REPARSE_DATA == lfndta.err ||
+         ERROR_CANT_ACCESS_FILE == lfndta.err) {
 
          iError = IDS_BADPATHMSG;
          goto InvalidDirectory;
@@ -730,6 +732,8 @@ CreateDTABlockWorker(
 
          switch (lfndta.err) {
          case ERROR_PATH_NOT_FOUND:
+         case ERROR_CANT_ACCESS_FILE:
+         case ERROR_INVALID_REPARSE_DATA:
 
 InvalidDirectory:
 

--- a/src/wfsearch.c
+++ b/src/wfsearch.c
@@ -228,6 +228,8 @@ MemoryError:
       (bRoot ||
          ERROR_ACCESS_DENIED != lfndta.err &&
          ERROR_PATH_NOT_FOUND != lfndta.err &&
+         ERROR_INVALID_REPARSE_DATA != lfndta.err &&
+         ERROR_CANT_ACCESS_FILE != lfndta.err &&
          ERROR_INVALID_NAME != lfndta.err)) {
 
       SearchInfo.eStatus = SEARCH_ERROR;


### PR DESCRIPTION
### Problem
Search stops with error when it comes along an illegal reparse point. (This is not a dangling reparse point, but an illegal!)
An illegal reparse point contains illegal reparse data.

### Comments on the code
Basically it is an extension of the error handling in two places, which deals with error codes that come from illegal reparse data.
I accidentally stumbled across such a situation, when the search for a file stopped with the message 'The data present in the reparse point buffer is invalid.` This is ERROR_INVALID_REPARSE_DATA

Then I started to create illegal reparse points via the debugger with an extra tool, and found ERROR_CANT_ACCESS_FILE to be malicious too. Both are handled now.

