### PR TITLE
Wrong selection when typing _

### DIFF
--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -646,8 +646,12 @@ DirWndProc(
          return -2L;
 
       int pos = (i + j) % cItems;
-      if ('_' == LOWORD(wParam))
-         SendMessage(hwndLB, LB_SETSEL, 1, pos);
+
+      // There is a weird behavior in listbox which selects all between anchor an caret
+      // if SHIFT is pressed. Since we return the position here and thus caret will be 
+      // updated, anchor is behind, and pressing shift selects all between anchor and caret
+      // To overcome this we select the current position, and bring anchor and cart in sync.
+      SendMessage(hwndLB, LB_SETSEL, 1, pos);
 
       return pos;
    }

--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -608,6 +608,7 @@ DirWndProc(
       LPWSTR szItem;
       WCHAR rgchMatch[MAXPATHLEN];
       SIZE_T cchMatch;
+      UINT pos;
 
       if ((ch = LOWORD(wParam)) <= CHAR_SPACE || !GetWindowLongPtr(hwnd, GWL_HDTA))
          return(-1L);
@@ -645,7 +646,7 @@ DirWndProc(
       if (j == cItems)
          return -2L;
 
-      int pos = (i + j) % cItems;
+      pos = (i + j) % cItems;
 
       // There is a weird behavior in listbox which selects all between anchor an caret
       // if SHIFT is pressed. Since we return the position here and thus caret will be 

--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -645,7 +645,11 @@ DirWndProc(
       if (j == cItems)
          return -2L;
 
-      return((i + j) % cItems);
+      int pos = (i + j) % cItems;
+      if ('_' == LOWORD(wParam))
+         SendMessage(hwndLB, LB_SETSEL, 1, pos);
+
+      return pos;
    }
    case WM_COMPAREITEM:
 


### PR DESCRIPTION
### Problem
The directory pane suffers from some weird behavior of the list box. If you press _ it selects from anchor to caret:

- Run [wrong_selection.zip](https://github.com/microsoft/winfile/files/8682133/wrong_selection.zip). It creates a few almost empty files in a directory.
![wrong_selection](https://user-images.githubusercontent.com/7418603/168156654-ce6aca3c-c163-445c-8067-93f4850e8a43.png)
- Select the file installservices.exe
- Start typing 'i' 'n' 't' '\_'
You will end up with this
![bad_selection](https://user-images.githubusercontent.com/7418603/168157123-9b0936d0-8ba8-432c-b707-0699ab974dd0.png)

But all you wanted was to type 'int_' have 'int_bla.dll' selected

### Comments on the code
Well this was hard to find out, but it seems the used listbox in Winfile from comctl32.dll has a virtual key behind '\_', which selects all items from anchor to caret.
In wfdir.c:603 @ WM_CHARTOITEM at the return of the 'case', the actual position is returned with respect to the typed character.
If e.g. anchor = 2, and caret = 2, and this case statements returns 5, because the item with '\_' was on the 5th position, then internally the caret is set to 5. This works perfectly as long the typed character is != '\_'.
If it was '\_' the comctl32.dll magic happens, and it selects from anchor (2) to recently returned and set caret (5).
But you don't want this.

To solve this we check for the magic '\_' character and then select it via LB_SETSEL and thus correct anchor and caret before.

It is definitely comctl32.dll which causes this unexpected selection, because I debugged this and it happens within Sel_BlockHilite() inside comctl32.dll. If this is a bug or a feature, I don't know. 

I also checked with a very old version on this branch, and this behavior is in ever since.
