### PR TITLE
Fix toolbar customize

### DIFF
--- a/src/tbar.c
+++ b/src/tbar.c
@@ -74,8 +74,8 @@ static TBBUTTON tbButtons[] = {
   {11, IDM_COPY       , TBSTATE_ENABLED, TBSTYLE_BUTTON, 0 },
   {12, IDM_MOVE       , TBSTATE_ENABLED, TBSTYLE_BUTTON, 0 },
   {13, IDM_DELETE     , TBSTATE_ENABLED, TBSTYLE_BUTTON, 0 },
-  { 0, 0              , TBSTATE_ENABLED, TBSTYLE_SEP   , 0 },
   // IDM_PERMISSIONS not shown anymore, because there is no way to use the old acledit functionality with W7/10/11
+  // { 0, 0              , TBSTATE_ENABLED, TBSTYLE_SEP   , 0 },
   // {27, IDM_PERMISSIONS, TBSTATE_ENABLED, TBSTYLE_BUTTON, 0 },
 };
 


### PR DESCRIPTION
I tried to use the customize toolbar feature, and found it had a subtle assumption that was modified in #324 .

`GetAdjustInfo` copies the final toolbar item (`tbButtons[TBAR_BUTTON_COUNT-1]`) and uses it to fill in all undefined fields when populating the customize dialog.  #324 changed the final button to be a separator, so everything in the customize dialog has the separator flag set.  This means all of the strings and icons are missing in the dialog, and attempting to move any icon ends up replacing the icon with a separator, so it's invisible and inaccessible.