### PR TITLE
Fix x64 warnings

### DIFF
--- a/src/tbar.c
+++ b/src/tbar.c
@@ -272,7 +272,7 @@ EnableCheckTBButtons(HWND hwndActive)
    // if the active window is a search window or lacks a directory pane,
    // else enable them all.
 
-   dwSort = GetWindowLongPtr(hwndActive, GWL_SORT) - IDD_NAME + IDM_BYNAME;
+   dwSort = (DWORD)GetWindowLongPtr(hwndActive, GWL_SORT) - IDD_NAME + IDM_BYNAME;
 
    fEnable = ((int)GetWindowLongPtr(hwndActive, GWL_TYPE) >= 0 &&
       HasDirWindow(hwndActive));
@@ -716,7 +716,7 @@ UnlockAndReturn:
       if (lpButton->fsStyle & TBSTYLE_SEP)
          goto LoadDescription;
 
-      iExt = lpButton->dwData - 1; // can now directly determine the extension with which the button is associated
+      iExt = (INT)(lpButton->dwData - 1); // can now directly determine the extension with which the button is associated
 
       if ((UINT)iExt < (UINT)iNumExtensions) {
          tbl.idCommand = lpButton->idCommand % 100;
@@ -773,7 +773,7 @@ HandleToolbarSave(LPNMTBSAVE lpnmtSave)
         // for extension buttons, remove bias for both idCommand and iBitmap
         if (lpnmtSave->tbButton.dwData != 0)
         {
-            INT iExt = lpnmtSave->tbButton.dwData - 1;
+            INT iExt = (INT)(lpnmtSave->tbButton.dwData - 1);
             baseId = extensions[iExt].Delta;
             baseIbm = extensions[iExt].iStartBmp;
         }
@@ -1060,7 +1060,7 @@ NormalHelp:
            FMS_HELPSTRING tbl;
 
 
-           iExt = lpTT->hdr.idFrom/100 - IDM_EXTENSIONS - 1;
+           iExt = (int)(lpTT->hdr.idFrom/100 - IDM_EXTENSIONS - 1);
 
            if (hwndExtensions && ((UINT)iExt < (UINT)iNumExtensions)) {
                tbl.idCommand = lpTT->hdr.idFrom % 100;
@@ -1081,7 +1081,7 @@ NormalHelp:
                StrNCpy(lpTT->szText, tbl.szHelp, MAXDESCLEN - 1);
 
            } else {
-               idString = lpTT->hdr.idFrom + MH_MYITEMS;
+               idString = (UINT)(lpTT->hdr.idFrom + MH_MYITEMS);
 
                if (lpTT->hdr.idFrom == IDM_CONNECTIONS) {
                    idString = IDM_CONNECT + MH_MYITEMS;
@@ -1477,6 +1477,7 @@ AddExtensionToolbarButtons(BOOL bAll)
     nExtButtons = (INT)SendMessage(hwndExtensions, TB_BUTTONCOUNT, 0, 0L);
     for (INT nItem = 0; nItem < nExtButtons; ++nItem)
     {
+        INT iExt;
         SendMessage(hwndExtensions, TB_GETBUTTON, nItem,
             (LPARAM)(LPTBBUTTON)&tbButton);
 
@@ -1487,7 +1488,7 @@ AddExtensionToolbarButtons(BOOL bAll)
         }
 
         // map idCommand and iBitmap if this is a valid extension
-        INT iExt = tbButton.dwData - 1;
+        iExt = (INT)(tbButton.dwData - 1);
         if ((UINT)iExt < (UINT)iNumExtensions)
         {
             // if we are not loading them all and this button's extension was seen during toolbar restore, skip

--- a/src/treectl.c
+++ b/src/treectl.c
@@ -376,7 +376,7 @@ InsertDirectory(
    x = GetRealExtent(pNode, hwndLB, NULL, &len);
    x = CALC_EXTENT(pNode);
 
-   xTreeMax = GetWindowLongPtr(hwndTreeCtl, GWL_XTREEMAX);
+   xTreeMax = (UINT)GetWindowLongPtr(hwndTreeCtl, GWL_XTREEMAX);
    if (x > xTreeMax)
    {
        SetWindowLongPtr(hwndTreeCtl, GWL_XTREEMAX, x);
@@ -596,26 +596,26 @@ ReadDirLevel(
    LPTSTR  szAutoExpand,
    BOOL bPartialSort)
 {
-   LPWSTR      szEndPath;
+   LPWSTR    szEndPath;
    LFNDTA    lfndta;
    INT       iNode;
    BOOL      bFound;
-   PDNODE     pNode;
+   PDNODE    pNode;
    BOOL      bAutoExpand;
    BOOL      bResult = TRUE;
    DWORD     dwView;
    HWND      hwndParent;
    HWND      hwndDir;
    LPXDTALINK lpStart;
-   LPXDTA*  plpxdta;
-   LPXDTA   lpxdta;
+   LPXDTA*   plpxdta;
+   LPXDTA    lpxdta;
    INT       count;
 
    UINT      uYieldCount = 0;
 
    hwndParent = GetParent(hwndTreeCtl);
 
-   dwView = GetWindowLongPtr(hwndParent, GWL_VIEW);
+   dwView = (DWORD)GetWindowLongPtr(hwndParent, GWL_VIEW);
 
    //
    // we optimize the tree read if we are not adding pluses and
@@ -793,7 +793,7 @@ ReadDirLevel(
 
       if (bCancelTree) {
 
-         INT iDrive = GetWindowLongPtr(hwndParent, GWL_TYPE);
+         INT iDrive = (INT)GetWindowLongPtr(hwndParent, GWL_TYPE);
 
          if (!IsValidDisk(iDrive))
             PostMessage(hwndParent, WM_SYSCOMMAND, SC_CLOSE, 0L);
@@ -1170,7 +1170,7 @@ FillTreeListbox(HWND hwndTC,
 
       if (pNode) {
 
-         dwAttribs = GetWindowLongPtr(GetParent(hwndTC), GWL_ATTRIBS);
+         dwAttribs = (DWORD)GetWindowLongPtr(GetParent(hwndTC), GWL_ATTRIBS);
          dwAttribs = ATTR_DIR | (dwAttribs & (ATTR_HS | ATTR_JUNCTION));
          cNodes = 0;
          bCancelTree = FALSE;
@@ -1242,7 +1242,7 @@ FillOutTreeList(HWND hwndTC,
 
 	SendMessage(hwndLB, WM_SETREDRAW, FALSE, 0L);
 
-	dwAttribs = GetWindowLongPtr(GetParent(hwndTC), GWL_ATTRIBS);
+	dwAttribs = (DWORD)GetWindowLongPtr(GetParent(hwndTC), GWL_ATTRIBS);
 	dwAttribs = ATTR_DIR | (dwAttribs & (ATTR_HS | ATTR_JUNCTION));
 
 	// get path to node that already exists in tree; will start reading from there
@@ -1484,7 +1484,7 @@ EmptyStatusAndReturn:
       StripBackslash(szPath);
 
       SetStatusText(SBT_NOBORDERS|255, SST_FORMAT|SST_RESOURCE,
-               (LPCTSTR)(DWORD)(fShowSourceBitmaps ? IDS_DRAG_COPYING : IDS_DRAG_MOVING),
+               (LPCTSTR)(DWORD_PTR)(fShowSourceBitmaps ? IDS_DRAG_COPYING : IDS_DRAG_MOVING),
                szPath);
       UpdateWindow(hwndStatus);
 
@@ -1709,7 +1709,7 @@ TCWP_DrawItem(
       {
             // Blt the proper folder bitmap
 
-            view = GetWindowLongPtr(GetParent(hWnd), GWL_VIEW);
+            view = (DWORD)GetWindowLongPtr(GetParent(hWnd), GWL_VIEW);
 
             if (IsNetPath(pNode)) {
                 if (bDrawSelected)
@@ -1907,7 +1907,7 @@ CollapseLevel(HWND hwndLB, PDNODE pNode, INT nIndex)
   /* Disable redrawing early. */
   SendMessage(hwndLB, WM_SETREDRAW, FALSE, 0L);
 
-  xTreeMax = GetWindowLongPtr(GetParent(hwndLB), GWL_XTREEMAX);
+  xTreeMax = (UINT)GetWindowLongPtr(GetParent(hwndLB), GWL_XTREEMAX);
 
   nIndexT++;
 
@@ -2012,7 +2012,7 @@ ExpandLevel(HWND hWnd, WPARAM wParam, INT nIndex, LPTSTR szPath)
 
   if (IsTheDiskReallyThere(hWnd, szPath, FUNC_EXPAND, FALSE))
   {
-     dwAttribs = GetWindowLongPtr(GetParent(hWnd), GWL_ATTRIBS);
+     dwAttribs = (DWORD)GetWindowLongPtr(GetParent(hWnd), GWL_ATTRIBS);
      dwAttribs = ATTR_DIR | (dwAttribs & (ATTR_HS | ATTR_JUNCTION));
      ReadDirLevel(hWnd, pNode, szPath, pNode->nLevels + 1, nIndex, dwAttribs,
         (BOOL)wParam, NULL, IS_PARTIALSORT(DRIVEID(szPath)));
@@ -2330,7 +2330,7 @@ TreeControlWndProc(
          if (cchMatch > wcslen(pNode->szName))
                 cchMatch = wcslen(pNode->szName);
          if (CompareString( LOCALE_USER_DEFAULT, NORM_IGNORECASE, 
-             rgchMatch, cchMatch, pNode->szName, cchMatch) == 2)
+             rgchMatch, (INT)cchMatch, pNode->szName, (INT)cchMatch) == 2)
             break;
 
       }
@@ -2569,7 +2569,7 @@ TreeControlWndProc(
          //
          // CurSel is returned from SendMessage
          //
-         CurSel = SendMessage(hwnd, TC_GETDIR, (WPARAM) -1,(LPARAM)szPath);
+         CurSel = (INT)SendMessage(hwnd, TC_GETDIR, (WPARAM) -1,(LPARAM)szPath);
          if (CurSel == -1)
          {
              break;
@@ -3108,7 +3108,7 @@ SameSelection:
          {
             HWND hwndLB;
 
-            bChangeDisplay = GetWindowLongPtr(hwndDir, GWLP_USERDATA);
+            bChangeDisplay = (BOOL)GetWindowLongPtr(hwndDir, GWLP_USERDATA);
 
             hwndLB = GetDlgItem (hwndDir, IDCW_LISTBOX);
             if (hwndLB && !bChangeDisplay)
@@ -3315,7 +3315,7 @@ ResetTreeMax(
     UINT xNew, xTreeMax;
 
 
-    NumItems = SendMessage(hwndLB, LB_GETCOUNT, 0, 0);
+    NumItems = (DWORD)SendMessage(hwndLB, LB_GETCOUNT, 0, 0);
 
     xTreeMax = 0;
 

--- a/src/wfassoc.c
+++ b/src/wfassoc.c
@@ -313,7 +313,7 @@ UpdateSelectionExt(HWND hDlg, BOOL bForce)
    // the text in the edit field.
    //
    if (bForce) {
-      i = SendDlgItemMessage(hDlg, IDD_EXT, CB_GETCURSEL, 0, 0L);
+      i = (INT)SendDlgItemMessage(hDlg, IDD_EXT, CB_GETCURSEL, 0, 0L);
       SendDlgItemMessage(hDlg, IDD_EXT, CB_GETLBTEXT, i, (LPARAM)szExt);
    } else {
 
@@ -631,7 +631,7 @@ DoConfigWinIni:
          //
          // Find which item to remove
          //
-         i = SendDlgItemMessage(hDlg, IDD_CLASSLIST, LB_GETCURSEL, 0, 0L);
+         i = (INT)SendDlgItemMessage(hDlg, IDD_CLASSLIST, LB_GETCURSEL, 0, 0L);
 
          //
          // Should never be 0...  If so, we're in trouble since
@@ -739,7 +739,7 @@ DoConfigWinIni:
          //
          // Set it to the next thing
          //
-         dwError = SendDlgItemMessage(hDlg, IDD_CLASSLIST, LB_SETCURSEL, i, 0L);
+         dwError = (DWORD)SendDlgItemMessage(hDlg, IDD_CLASSLIST, LB_SETCURSEL, i, 0L);
          if (LB_ERR == dwError)
             i--;
 
@@ -1257,7 +1257,7 @@ AssociateFileDlgCommand(HWND hDlg,
                      //
                      // Found one, Highlight!
                      //
-                     i = SendDlgItemMessage(hDlg, IDD_EXTLIST, LB_FINDSTRINGEXACT,
+                     i = (INT)SendDlgItemMessage(hDlg, IDD_EXTLIST, LB_FINDSTRINGEXACT,
                         (WPARAM)-1, (LPARAM) &szExt[1]);
 
                      SendDlgItemMessage(hDlg, IDD_EXTLIST, LB_SETCURSEL, i, 0L);
@@ -1372,7 +1372,7 @@ AddDelUpdate:
       if (BN_CLICKED == GET_WM_COMMAND_CMD(wParam, lParam))
       {
          i = pAssociateFileDlgInfo->iAction =
-            SendDlgItemMessage(hDlg, IDD_ACTION, CB_GETCURSEL, 0, 0L);
+            (INT)SendDlgItemMessage(hDlg, IDD_ACTION, CB_GETCURSEL, 0, 0L);
 
          DDEDlgRead(hDlg, pAssociateFileDlgInfo, i);
          pAssociateFileDlgInfo->DDEInfo[i].bUsesDDE =
@@ -2281,7 +2281,7 @@ FileTypeRead(HWND hDlg,
          if (!pExt->bDelete)
          {
             CharLower(&pExt->szExt[1]);
-            i = SendDlgItemMessage(hDlg, IDD_EXTLIST, LB_ADDSTRING, 0, (LPARAM)&pExt->szExt[1]);
+            i = (UINT)SendDlgItemMessage(hDlg, IDD_EXTLIST, LB_ADDSTRING, 0, (LPARAM)&pExt->szExt[1]);
 
             SendDlgItemMessage(hDlg, IDD_EXTLIST, LB_SETITEMDATA, i, (LPARAM)pExt);
          }
@@ -2859,7 +2859,7 @@ ActionUpdate(HWND hDlg,
 {
     INT i;
 
-    i = SendDlgItemMessage(hDlg, IDD_ACTION, CB_GETCURSEL, 0, 0L);
+    i = (INT)SendDlgItemMessage(hDlg, IDD_ACTION, CB_GETCURSEL, 0, 0L);
 
     //
     // Update out internal variable
@@ -3138,11 +3138,11 @@ AssociateFileDlgExtDelete(HWND hDlg,
     GetDlgItemText(hDlg, IDD_EXT, pAssociateFileDlgInfo->szExt, COUNTOF(pAssociateFileDlgInfo->szExt));
     ExtClean(pAssociateFileDlgInfo->szExt);
 
-    i = SendDlgItemMessage( hDlg,
-                            IDD_EXTLIST,
-                            LB_FINDSTRINGEXACT,
-                            (WPARAM)-1,
-                            (LPARAM)&pAssociateFileDlgInfo->szExt[1]);
+    i = (INT)SendDlgItemMessage( hDlg,
+                                 IDD_EXTLIST,
+                                 LB_FINDSTRINGEXACT,
+                                 (WPARAM)-1,
+                                 (LPARAM)&pAssociateFileDlgInfo->szExt[1]);
     if (LB_ERR == i)
     {
         return (FALSE);
@@ -3468,11 +3468,11 @@ RegExtDelete(HWND hDlg, HKEY hk, PEXT pExt)
    
     if (ERROR_SUCCESS == dwError)
     {
-        i = SendDlgItemMessage( hDlg,
-                                IDD_EXT,
-                                CB_FINDSTRINGEXACT,
-                                (WPARAM)-1,
-                                (LPARAM)&pExt->szExt[1] );
+        i = (INT)SendDlgItemMessage( hDlg,
+                                     IDD_EXT,
+                                     CB_FINDSTRINGEXACT,
+                                     (WPARAM)-1,
+                                     (LPARAM)&pExt->szExt[1] );
         if (CB_ERR != i)
         {
             SendDlgItemMessage(hDlg, IDD_EXT, CB_DELETESTRING, i, 0L);

--- a/src/wfchgnot.c
+++ b/src/wfchgnot.c
@@ -273,7 +273,7 @@ NotifyResume(DRIVE drive, UINT uType)
       hwnd;
       hwnd = GetWindow(hwnd, GW_HWNDNEXT)) {
 
-      driveCurrent = GetWindowLongPtr(hwnd, GWL_TYPE);
+      driveCurrent = (DRIVE)GetWindowLongPtr(hwnd, GWL_TYPE);
 
       //
       // Skip search window

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -1180,7 +1180,7 @@ AppCommandProc(register DWORD id)
 	  if(szFiles == NULL && pDataObj != NULL && pDataObj->lpVtbl->GetData(pDataObj, &fmtetcDrop, &stgmed) == S_OK)
 	  {
 	  	LPWSTR lpFile = GlobalLock(stgmed.hGlobal);
-	  	DWORD cchFile = wcslen(lpFile);
+	  	SIZE_T cchFile = wcslen(lpFile);
 		szFiles = (LPWSTR)LocalAlloc(LMEM_FIXED, (cchFile+3) * sizeof(WCHAR));
 		lstrcpy (szFiles+1, lpFile);
 		*szFiles = '\"';
@@ -1638,7 +1638,7 @@ AppCommandProc(register DWORD id)
 
       } else {
          dwSuperDlgMode = id;
-         ret = DialogBox(hAppInstance, MAKEINTRESOURCE(CHOOSEDRIVEDLG), hwndFrame, ChooseDriveDlgProc);
+         ret = (INT)DialogBox(hAppInstance, MAKEINTRESOURCE(CHOOSEDRIVEDLG), hwndFrame, ChooseDriveDlgProc);
       }
 
       break;
@@ -1971,7 +1971,7 @@ ChangeDisplay:
 
        // toggle pluses view bit
 
-       dwFlags = GetWindowLongPtr(hwndActive, GWL_VIEW) ^ VIEW_PLUSES;
+       dwFlags = (DWORD)(GetWindowLongPtr(hwndActive, GWL_VIEW) ^ VIEW_PLUSES);
 
        SetWindowLongPtr(hwndActive, GWL_VIEW, dwFlags);
 

--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -469,7 +469,7 @@ AddComponent:
              //
              if (lpszDot) {
 
-                nSpaceLeft += pT-lpszDot;
+                nSpaceLeft += (INT)(pT-lpszDot);
                 pT = lpszDot;
              }
 
@@ -1060,7 +1060,7 @@ ConfirmDialog(
 
    if ( CONFIRMNOACCESS == dlg || CONFIRMNOACCESSDEST == dlg) {
       params.bNoAccess = TRUE;
-      nRetVal = DialogBoxParam(hAppInstance, (LPTSTR)MAKEINTRESOURCE(dlg), hDlg, ReplaceDlgProc, (LPARAM)(LPPARAM_REPLACEDLG)&params);
+      nRetVal = (INT)DialogBoxParam(hAppInstance, (LPTSTR)MAKEINTRESOURCE(dlg), hDlg, ReplaceDlgProc, (LPARAM)(LPPARAM_REPLACEDLG)&params);
 
    } else if (plfndtaDest->fd.dwFileAttributes & (ATTR_READONLY | ATTR_SYSTEM | ATTR_HIDDEN)) {
 
@@ -1070,7 +1070,7 @@ ConfirmDialog(
          nRetVal = IDYES;
       } else {
          params.bWriteProtect = TRUE;
-         nRetVal = DialogBoxParam(hAppInstance, (LPTSTR)MAKEINTRESOURCE(dlg), hDlg, ReplaceDlgProc, (LPARAM)(LPPARAM_REPLACEDLG)&params);
+         nRetVal = (INT)DialogBoxParam(hAppInstance, (LPTSTR)MAKEINTRESOURCE(dlg), hDlg, ReplaceDlgProc, (LPARAM)(LPPARAM_REPLACEDLG)&params);
       }
 
       if (nRetVal == IDYES) {
@@ -1086,7 +1086,7 @@ ConfirmDialog(
       nRetVal = IDYES;
    } else {
 
-      nRetVal = DialogBoxParam(hAppInstance, (LPTSTR) MAKEINTRESOURCE(dlg), hDlg, ReplaceDlgProc, (LPARAM)(LPPARAM_REPLACEDLG)&params);
+      nRetVal = (INT)DialogBoxParam(hAppInstance, (LPTSTR) MAKEINTRESOURCE(dlg), hDlg, ReplaceDlgProc, (LPARAM)(LPPARAM_REPLACEDLG)&params);
    }
 
    if (nRetVal == -1)
@@ -3375,11 +3375,11 @@ Error:
    lstrcpy(pCopyInfo->pFrom, pFrom);
    lstrcpy(pCopyInfo->pTo, pTo);
 
-   dwStatus = DialogBoxParam(hAppInstance,
-                            (LPTSTR) MAKEINTRESOURCE(DMSTATUSDLG),
-                            hwndFrame,
-                            ProgressDlgProc,
-                            (LPARAM)pCopyInfo);
+   dwStatus = (DWORD)DialogBoxParam(hAppInstance,
+                                    (LPTSTR) MAKEINTRESOURCE(DMSTATUSDLG),
+                                    hwndFrame,
+                                    ProgressDlgProc,
+                                    (LPARAM)pCopyInfo);
 
    return dwStatus;
 }

--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -273,7 +273,7 @@ FocusOnly:
             rc = lpLBItem->rcItem;
             rc.right = max(rc.right,
                            rc.left +
-                           SendMessage(hwndLB, LB_GETHORIZONTALEXTENT, 0, 0)) -
+                           (INT)SendMessage(hwndLB, LB_GETHORIZONTALEXTENT, 0, 0)) -
                        dyBorder;
             rc.left += dyBorder;
 
@@ -638,7 +638,7 @@ DirWndProc(
                 cchMatch = wcslen(szItem);
 
          if (CompareString( LOCALE_USER_DEFAULT, NORM_IGNORECASE, 
-             rgchMatch, cchMatch, szItem, cchMatch) == 2)
+             rgchMatch, (int)cchMatch, szItem, (int)cchMatch) == 2)
             break;
 
       }
@@ -662,7 +662,7 @@ DirWndProc(
 
       return (LONG)CompareDTA((LPXDTA)lpci->itemData1,
                               (LPXDTA)lpci->itemData2,
-                              GetWindowLongPtr(hwndParent, GWL_SORT));
+                              (DWORD)GetWindowLongPtr(hwndParent, GWL_SORT));
 #undef lpci
 
    case WM_NCDESTROY:
@@ -756,7 +756,7 @@ DirWndProc(
    case WM_DRAWITEM:
 
       DrawItem(hwnd,
-               GetWindowLongPtr(hwndParent, GWL_VIEW),
+               (DWORD)GetWindowLongPtr(hwndParent, GWL_VIEW),
                (LPDRAWITEMSTRUCT)lParam,
                ((LPDRAWITEMSTRUCT)lParam)->hwndItem == GetFocus());
       break;
@@ -1106,7 +1106,7 @@ ChangeDisplay(
          // and Details view.
          //
          dwNewView = LOWORD(lParam);
-         dwCurView = GetWindowLongPtr(hwndListParms, GWL_VIEW);
+         dwCurView = (DWORD)GetWindowLongPtr(hwndListParms, GWL_VIEW);
 
          //
          // hiword lParam == TRUE means always refresh
@@ -1162,8 +1162,8 @@ ChangeDisplay(
          //
          // Create a new one (preserving the Sort setting).
          //
-         dwNewSort = GetWindowLongPtr(hwndListParms, GWL_SORT);
-         dwNewAttribs = GetWindowLongPtr(hwndListParms, GWL_ATTRIBS);
+         dwNewSort = (DWORD)GetWindowLongPtr(hwndListParms, GWL_SORT);
+         dwNewAttribs = (DWORD)GetWindowLongPtr(hwndListParms, GWL_ATTRIBS);
          SetWindowLongPtr(hwndListParms, GWL_VIEW, dwNewView);
 
          bCreateDTABlock = FALSE;	// and szPath is NOT set
@@ -1294,9 +1294,9 @@ ChangeDisplay(
          //
          // Create a new one (preserving the Sort setting)
          //
-         dwNewSort = GetWindowLongPtr(hwndListParms, GWL_SORT);
-         dwNewView = GetWindowLongPtr(hwndListParms, GWL_VIEW);
-         dwNewAttribs = GetWindowLongPtr(hwndListParms, GWL_ATTRIBS);
+         dwNewSort = (DWORD)GetWindowLongPtr(hwndListParms, GWL_SORT);
+         dwNewView = (DWORD)GetWindowLongPtr(hwndListParms, GWL_VIEW);
+         dwNewAttribs = (DWORD)GetWindowLongPtr(hwndListParms, GWL_ATTRIBS);
 
          SetWindowLongPtr(hwnd, GWLP_USERDATA, 1);
          SendMessage(hwndLB, LB_RESETCONTENT, 0, 0L);
@@ -1475,7 +1475,7 @@ CreateLB:
       SetLBFont(hwnd,
                 hwndLB,
                 hFont,
-                GetWindowLongPtr(hwndListParms, GWL_VIEW),
+                (DWORD)GetWindowLongPtr(hwndListParms, GWL_VIEW),
                 lpStart);
 
 
@@ -1878,7 +1878,7 @@ PutSize(
      *  unformatted.
      */
     lstrcpy(szOutStr, szBuffer);
-    return (wcslen(szOutStr));
+    return ((INT)wcslen(szOutStr));
 }
 
 
@@ -2354,7 +2354,7 @@ CharCountToTab(LPWSTR pszStr)
       pszStr++;
    }
 
-   return pszStr-pszTmp;
+   return (INT)(pszStr-pszTmp);
 }
 
 
@@ -2943,7 +2943,7 @@ GDSDone:
 
    if (bCompressTest)
    {
-       return ( (LPWSTR)uiAttr );
+       return ( (LPWSTR)(DWORD_PTR)uiAttr );
    }
 
    if (pfDir) {
@@ -3056,7 +3056,7 @@ DirGetAnchorFocus(
       lstrcpy(pSelInfo->szCaret, MemGetFileName(lpxdta));
    }
 
-   iSel = SendMessage(hwndLB, LB_GETTOPINDEX, 0, 0L);
+   iSel = (INT)SendMessage(hwndLB, LB_GETTOPINDEX, 0, 0L);
 
    if (iSel >= 0 && iSel < iCount) {
       SendMessage(hwndLB, LB_GETTEXT, (WPARAM)iSel, (LPARAM)&lpxdta);
@@ -3152,7 +3152,7 @@ UpdateStatus(HWND hwnd)
 
    if (HasTreeWindow(hwnd)) {
 
-      drive = GetWindowLongPtr(hwnd, GWL_TYPE);
+      drive = (DRIVE)GetWindowLongPtr(hwnd, GWL_TYPE);
 
       if (SPC_IS_NOTREE(qFreeSpace)) {
 
@@ -3434,9 +3434,9 @@ SortDirList(
    INT iMax, iMin, iMid;
    LPXDTA lpxdta;
 
-   dwSort = GetWindowLongPtr((HWND)GetWindowLongPtr(hwndDir,
-                                                   GWL_LISTPARMS),
-                               GWL_SORT);
+   dwSort = (DWORD)GetWindowLongPtr((HWND)GetWindowLongPtr(hwndDir,
+                                                           GWL_LISTPARMS),
+                                    GWL_SORT);
 
    lpxdta = MemFirst(lpStart);
 

--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -692,7 +692,7 @@ CreateDTABlockWorker(
 
    LeaveCriticalSection(&CriticalSectionDirRead);
 
-   dwAttribs = GetWindowLongPtr(hwnd, GWL_ATTRIBS);
+   dwAttribs = (DWORD)GetWindowLongPtr(hwnd, GWL_ATTRIBS);
 
    //
    // get the drive index assuming path is
@@ -1049,7 +1049,7 @@ Done:
    SetLBFont(hwndDir,
              GetDlgItem(hwndDir, IDCW_LISTBOX),
              hFont,
-             GetWindowLongPtr(hwnd, GWL_VIEW),
+             (DWORD)GetWindowLongPtr(hwnd, GWL_VIEW),
              lpStart);
 
    R_Space(drive);

--- a/src/wfdirsrc.c
+++ b/src/wfdirsrc.c
@@ -457,7 +457,7 @@ DSRectItem(
 
          SetStatusText(SBT_NOBORDERS|255,
                        SST_RESOURCE|SST_FORMAT,
-                       (LPWSTR)(fShowSourceBitmaps ?
+                       (LPWSTR)(DWORD_PTR)(fShowSourceBitmaps ?
                           IDS_DRAG_COPYING :
                           IDS_DRAG_MOVING),
                        szTemp);
@@ -519,7 +519,7 @@ ClearStatus:
 
       SetStatusText(SBT_NOBORDERS|255,
                     SST_FORMAT | SST_RESOURCE,
-                    (LPWSTR)(fShowSourceBitmaps ?
+                    (LPWSTR)(DWORD_PTR)(fShowSourceBitmaps ?
                         IDS_DRAG_COPYING :
                         IDS_DRAG_MOVING),
                     szTemp);
@@ -556,7 +556,7 @@ ClearStatus:
 
       SetStatusText(SBT_NOBORDERS|255,
                     SST_FORMAT | SST_RESOURCE,
-                    (LPWSTR)(pIsProgram ?
+                    (LPWSTR)(DWORD_PTR)(pIsProgram ?
                        IDS_DRAG_EXECUTING :
                        (fShowSourceBitmaps ?
                           IDS_DRAG_COPYING :
@@ -772,7 +772,7 @@ DSTrackPoint(
    if (GetKeyState(VK_SHIFT) < 0) {
 
       // What is the state of the Anchor point?
-      dwAnchor = SendMessage(hwndLB, LB_GETANCHORINDEX, 0, 0L);
+      dwAnchor = (DWORD)SendMessage(hwndLB, LB_GETANCHORINDEX, 0, 0L);
       bSelected = (BOOL)SendMessage(hwndLB, LB_GETSEL, dwAnchor, 0L);
 
       // If Control is up, turn everything off.

--- a/src/wfdlgs.c
+++ b/src/wfdlgs.c
@@ -63,7 +63,7 @@ DO_AGAIN:
 
    for (hwnd = GetWindow(hwndMDIClient, GW_CHILD); hwnd; hwnd = GetWindow(hwnd, GW_HWNDNEXT)) {
       HWND ht = HasTreeWindow(hwnd);
-      INT nReadLevel = ht ? GetWindowLongPtr(ht, GWL_READLEVEL) : 0;
+      INT nReadLevel = ht ? (INT)GetWindowLongPtr(ht, GWL_READLEVEL) : 0;
 
       // don't save MDI icon title windows or search windows,
       // or any dir window which is currently recursing
@@ -79,9 +79,9 @@ DO_AGAIN:
          wp.length = sizeof(WINDOWPLACEMENT);
          if (!GetWindowPlacement(hwnd, &wp))
              continue;
-         view = GetWindowLongPtr(hwnd, GWL_VIEW);
-         sort = GetWindowLongPtr(hwnd, GWL_SORT);
-         attribs = GetWindowLongPtr(hwnd, GWL_ATTRIBS);
+         view = (DWORD)GetWindowLongPtr(hwnd, GWL_VIEW);
+         sort = (DWORD)GetWindowLongPtr(hwnd, GWL_SORT);
+         attribs = (DWORD)GetWindowLongPtr(hwnd, GWL_ATTRIBS);
 
          GetMDIWindowText(hwnd, szPath, COUNTOF(szPath));
 
@@ -145,7 +145,7 @@ OtherDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
     {
       case WM_INITDIALOG:
 
-          dwView = GetWindowLongPtr(hwndActive, GWL_VIEW);
+          dwView = (DWORD)GetWindowLongPtr(hwndActive, GWL_VIEW);
           CheckDlgButton(hDlg, IDD_SIZE,  dwView & VIEW_SIZE);
           CheckDlgButton(hDlg, IDD_DATE,  dwView & VIEW_DATE);
           CheckDlgButton(hDlg, IDD_TIME,  dwView & VIEW_TIME);
@@ -608,7 +608,7 @@ NewFont()
             SetLBFont(hwndT,
                       hwndT2,
                       hFont,
-                      GetWindowLongPtr(hwnd, GWL_VIEW),
+                      (DWORD)GetWindowLongPtr(hwnd, GWL_VIEW),
                       (LPXDTALINK)GetWindowLongPtr(hwndT, GWL_HDTA));
 
             InvalidateRect(hwndT2, NULL, TRUE);
@@ -849,7 +849,7 @@ ActivateCommonContextMenu(HWND hwnd, HWND hwndLB, LPARAM lParam)
 	{
 		RECT rect;
 
-		item = SendMessage(hwndLB, LB_GETCURSEL, 0, 0);
+		item = (DWORD)SendMessage(hwndLB, LB_GETCURSEL, 0, 0);
 		SendMessage(hwndLB, LB_GETITEMRECT, (WPARAM)LOWORD(item), (LPARAM)&rect);
 		pt.x = rect.left;
 		pt.y = rect.bottom;
@@ -861,7 +861,7 @@ ActivateCommonContextMenu(HWND hwnd, HWND hwndLB, LPARAM lParam)
 		POINTSTOPOINT(pt, lParam);
 
 		ScreenToClient(hwndLB, &pt);
-		item = SendMessage(hwndLB, LB_ITEMFROMPOINT, 0, POINTTOPOINTS(pt));
+		item = (DWORD)SendMessage(hwndLB, LB_ITEMFROMPOINT, 0, POINTTOPOINTS(pt));
 
 		if (HIWORD(item) == 0)
 		{

--- a/src/wfdlgs2.c
+++ b/src/wfdlgs2.c
@@ -435,6 +435,7 @@ CALLBACK
 SuperDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
    UINT          len;
+   INT           iCtrl;
    LPTSTR        pszFrom;
    //
    // WFMoveCopyDrive tries to append \*.* to directories and
@@ -526,7 +527,7 @@ JAPANEND
          SetDlgItemText(hDlg, IDD_FROM, p);
 
          if ((dwSuperDlgMode == IDM_PRINT) || (dwSuperDlgMode == IDM_DELETE))
-            wParam = IDD_FROM;
+            iCtrl = IDD_FROM;
          else
          {
             TCHAR szDirs[MAXPATHLEN];
@@ -534,11 +535,11 @@ JAPANEND
             int drive, driveCur;
         	BOOL fFirst = TRUE;
             
-            wParam = IDD_TO;
+            iCtrl = IDD_TO;
             if (dwSuperDlgMode == IDM_RENAME)
 	            SetDlgItemText(hDlg, IDD_TO, p);
 
-			driveCur = GetWindowLongPtr(hwndActive, GWL_TYPE);
+			driveCur = (int)GetWindowLongPtr(hwndActive, GWL_TYPE);
 
 			lstrcpy(szDirs, TEXT("Other: "));
 
@@ -565,7 +566,7 @@ JAPANEND
 	        SetDlgItemText(hDlg, IDD_DIRS, szDirs);
          }
 
-         SendDlgItemMessage(hDlg, wParam, EM_LIMITTEXT, COUNTOF(szTo) - 1, 0L);
+         SendDlgItemMessage(hDlg, iCtrl, EM_LIMITTEXT, COUNTOF(szTo) - 1, 0L);
          LocalFree((HANDLE)p);
          break;
       }
@@ -1165,7 +1166,7 @@ FillVersionList(HWND hDlg)
 
       goto Done;
 
-   idx = SendMessage(hwndLB, LB_ADDSTRING, 0, (LPARAM)szMessage);
+   idx = (INT)SendMessage(hwndLB, LB_ADDSTRING, 0, (LPARAM)szMessage);
    if (idx == LB_ERR)
       goto Done;
 
@@ -1284,7 +1285,7 @@ InitPropertiesDialog(
       hwndView = hwndActive;
    }
 
-   iMac = SendMessage(hwndLB, LB_GETCOUNT, 0, 0L);
+   iMac = (INT)SendMessage(hwndLB, LB_GETCOUNT, 0, 0L);
 
    szPath[0] = CHAR_NULL;
    szName[0] = CHAR_NULL;
@@ -1513,7 +1514,7 @@ FullPath:
                WS_VISIBLE|WS_CHILD|WS_TABSTOP|BS_PUSHBUTTON,
                rc.left, rc.top,
                rc.right - rc.left, rc.bottom-rc.top,
-               hDlg, (HMENU)(i + IDD_NETWORKFIRST), hAppInstance, NULL);
+               hDlg, (HMENU)(DWORD_PTR)(i + IDD_NETWORKFIRST), hAppInstance, NULL);
 
             if (hwnd) {
                hFont = (HFONT)SendDlgItemMessage(hDlg, IDOK, WM_GETFONT, 0, 0L);

--- a/src/wfdlgs3.c
+++ b/src/wfdlgs3.c
@@ -298,7 +298,7 @@ FormatDiskette(HWND hwnd, BOOL bModal)
 
     CancelInfo.bModal = bModal;
 
-    res = DialogBox(hAppInstance, (LPTSTR) MAKEINTRESOURCE(FORMATDLG), hwnd, FormatDlgProc);
+    res = (INT)DialogBox(hAppInstance, (LPTSTR) MAKEINTRESOURCE(FORMATDLG), hwnd, FormatDlgProc);
 
     dwContext = dwSave;
 }
@@ -768,7 +768,7 @@ FormatSelectDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
                     {
                         // Set the drive letter as the string and the drive index as the data.
                         DRIVESET(szDrive, drive);
-                        comboxIndex = SendMessage(hwndSelectDrive, CB_ADDSTRING, 0, (LPARAM)szDrive);
+                        comboxIndex = (INT)SendMessage(hwndSelectDrive, CB_ADDSTRING, 0, (LPARAM)szDrive);
                         SendMessage(hwndSelectDrive, CB_SETITEMDATA, comboxIndex, (LPARAM)drive);
                     }
                 }
@@ -1427,7 +1427,7 @@ UpdateConnections(BOOL bUpdateDriveList)
       if (GetWindow(hwnd, GW_OWNER) || hwnd == hwndSearch)
          continue;
 
-      drive = GetWindowLongPtr(hwnd, GWL_TYPE);
+      drive = (DRIVE)GetWindowLongPtr(hwnd, GWL_TYPE);
 
       //
       // IsValidDisk uses GetDriveType which was updated if

--- a/src/wfdrives.c
+++ b/src/wfdrives.c
@@ -146,9 +146,9 @@ NewTree(
    // take all the attributes from the current window
    // (except the filespec, we may want to change this)
    //
-   dwNewSort    = GetWindowLongPtr(hwndSrc, GWL_SORT);
-   dwNewView    = GetWindowLongPtr(hwndSrc, GWL_VIEW);
-   dwNewAttribs = GetWindowLongPtr(hwndSrc, GWL_ATTRIBS);
+   dwNewSort    = (DWORD)GetWindowLongPtr(hwndSrc, GWL_SORT);
+   dwNewView    = (DWORD)GetWindowLongPtr(hwndSrc, GWL_VIEW);
+   dwNewAttribs = (DWORD)GetWindowLongPtr(hwndSrc, GWL_ATTRIBS);
 
    hwnd = CreateTreeWindow(szDir, CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, dxSplit);
 
@@ -694,8 +694,8 @@ DrivesWndProc(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam)
 
   hwndChild = (HWND)SendMessage(hwndMDIClient, WM_MDIGETACTIVE, 0, 0L);
 
-  nDriveCurrent = GetWindowLongPtr(hWnd, GWL_CURDRIVEIND);
-  nDriveFocus = GetWindowLongPtr(hWnd, GWL_CURDRIVEFOCUS);
+  nDriveCurrent = (INT)GetWindowLongPtr(hWnd, GWL_CURDRIVEIND);
+  nDriveFocus = (INT)GetWindowLongPtr(hWnd, GWL_CURDRIVEFOCUS);
 
   switch (wMsg) {
       case WM_CREATE:
@@ -707,7 +707,7 @@ DrivesWndProc(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam)
           if (hwndChild == 0)
              nDrive = 0;
           else
-             nDrive = GetWindowLongPtr(hwndChild, GWL_TYPE);
+             nDrive = (INT)GetWindowLongPtr(hwndChild, GWL_TYPE);
 
 
 
@@ -751,7 +751,7 @@ DrivesWndProc(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam)
                    {
                       HWND hwndLB;
 
-                      bChangeDisplay = GetWindowLongPtr(hwndDir, GWLP_USERDATA);
+                      bChangeDisplay = (BOOL)GetWindowLongPtr(hwndDir, GWLP_USERDATA);
 
                       hwndLB = GetDlgItem (hwndDir, IDCW_LISTBOX);
                       if (hwndLB && !bChangeDisplay)
@@ -884,7 +884,7 @@ DrivesWndProc(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam)
          }
 
          SetStatusText(SBT_NOBORDERS|255, SST_FORMAT|SST_RESOURCE,
-            (LPTSTR)(DWORD)(fShowSourceBitmaps ? IDS_DRAG_COPYING : IDS_DRAG_MOVING),
+            (LPTSTR)(DWORD_PTR)(fShowSourceBitmaps ? IDS_DRAG_COPYING : IDS_DRAG_MOVING),
             szDir);
          UpdateWindow(hwndStatus);
 
@@ -912,7 +912,7 @@ DrivesWndProc(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam)
              }
 
          SetStatusText(SBT_NOBORDERS|255, SST_RESOURCE|SST_FORMAT,
-            (LPTSTR)(DWORD)(fShowSourceBitmaps ? IDS_DRAG_COPYING : IDS_DRAG_MOVING),
+            (LPTSTR)(DWORD_PTR)(fShowSourceBitmaps ? IDS_DRAG_COPYING : IDS_DRAG_MOVING),
             szDir);
          UpdateWindow(hwndStatus);
 

--- a/src/wfdrop.c
+++ b/src/wfdrop.c
@@ -50,7 +50,7 @@ void PaintRectItem(WF_IDropTarget *This, POINTL *ppt)
 		pt.y = ppt->y;
 		ScreenToClient(hwndLB, &pt);
 	
-		iItem = SendMessage(hwndLB, LB_ITEMFROMPOINT, 0, MAKELPARAM(pt.x, pt.y));
+		iItem = (DWORD)SendMessage(hwndLB, LB_ITEMFROMPOINT, 0, MAKELPARAM(pt.x, pt.y));
 		iItem &= 0xffff;
 		if (This->m_iItemSelected != -1 && This->m_iItemSelected == iItem)
 			return;
@@ -133,7 +133,7 @@ HDROP CreateDropFiles(POINT pt, BOOL fNC, LPTSTR pszFiles)
 {
     HANDLE hDrop;
     LPBYTE lpList;
-    UINT cbList;
+    SIZE_T cbList;
 	LPTSTR szSrc;
 
     LPDROPFILES lpdfs;
@@ -246,7 +246,8 @@ LPWSTR QuotedContentList(IDataObject *pDataObject)
             // Get the descriptor information
             STGMEDIUM sm_desc= {0,0,0};
             STGMEDIUM sm_content = {0,0,0};
-			unsigned int file_index, cchTempPath, cchFiles;
+			unsigned int file_index;
+            size_t cchTempPath, cchFiles;
             WCHAR szTempPath[MAX_PATH+1];
 
             hr = pDataObject->lpVtbl->GetData(pDataObject, &descriptor_format, &sm_desc);

--- a/src/wffile.c
+++ b/src/wffile.c
@@ -209,7 +209,7 @@ VOID CentreWindow(
     HWND    hwndParent;
     LONG    dx, dy;
     LONG    dxParent, dyParent;
-    LONG    Style;
+    DWORD   Style;
 
     //
     //  Get window rect.
@@ -222,7 +222,7 @@ VOID CentreWindow(
     //
     //  Get parent rect.
     //
-    Style = GetWindowLongPtr(hwnd, GWL_STYLE);
+    Style = (DWORD)GetWindowLongPtr(hwnd, GWL_STYLE);
     if ((Style & WS_CHILD) == 0)
     {
         hwndParent = GetDesktopWindow();
@@ -1771,11 +1771,11 @@ int CompressErrMessageBox(
     //
     //  Put up the error message box - ABORT, RETRY, IGNORE, IGNORE ALL.
     //
-    rc = DialogBoxParam( hAppInstance,
-                         (LPTSTR) MAKEINTRESOURCE(COMPRESSERRDLG),
-                         hwndFrame,
-                         CompressErrDialogProc,
-                         (LPARAM)szFile );
+    rc = (int)DialogBoxParam( hAppInstance,
+                              (LPTSTR) MAKEINTRESOURCE(COMPRESSERRDLG),
+                              hwndFrame,
+                              CompressErrDialogProc,
+                              (LPARAM)szFile );
 
     //
     //  Return the user preference.

--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -133,7 +133,7 @@ vector<PDNODE> TreeIntersection(vector<vector<PDNODE>>& trees)
 	}
 
 	// if just one, return it (after sort above)
-	int count = trees.size();
+	size_t count = trees.size();
 	if (count == 1)
 		return trees.at(0);
 
@@ -147,7 +147,7 @@ vector<PDNODE> TreeIntersection(vector<vector<PDNODE>>& trees)
 	vector<PDNODE>* first = nullptr;
 
 	// for all other result sets, merge
-	for (int i = 1; i < count; i++)
+	for (size_t i = 1; i < count; i++)
 	{
 		size_t out = 0;			// always start writing to the beginning of the output
 
@@ -510,7 +510,7 @@ LRESULT APIENTRY GotoEditSubclassProc(
 
 			if (lpmsg->message == WM_KEYDOWN && (lpmsg->wParam == VK_DOWN || lpmsg->wParam == VK_UP || lpmsg->wParam == VK_HOME || lpmsg->wParam == VK_END)) {
 				HWND hwndDlg = GetParent(hwnd);
-				DWORD iSel = SendDlgItemMessage(hwndDlg, IDD_GOTOLIST, LB_GETCURSEL, 0, 0);
+				DWORD iSel = (DWORD)SendDlgItemMessage(hwndDlg, IDD_GOTOLIST, LB_GETCURSEL, 0, 0);
 				if (iSel == LB_ERR)
 					iSel = 0;
 				else if (lpmsg->wParam == VK_DOWN)
@@ -521,7 +521,7 @@ LRESULT APIENTRY GotoEditSubclassProc(
 					iSel = 0;
 				else if (lpmsg->wParam == VK_END)
 				{
-					iSel = SendDlgItemMessage(hwndDlg, IDD_GOTOLIST, LB_GETCOUNT, 0, 0) - 1;
+					iSel = (DWORD)SendDlgItemMessage(hwndDlg, IDD_GOTOLIST, LB_GETCOUNT, 0, 0) - 1;
 				}
 				if (SendDlgItemMessage(hwndDlg, IDD_GOTOLIST, LB_SETCURSEL, iSel, 0) == LB_ERR) {
 					if (lpmsg->wParam == VK_DOWN)
@@ -594,10 +594,11 @@ GotoDirDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 		case IDOK:
 		{
 			TCHAR szPath[MAXPATHLEN];
+            DWORD iSel;
 
 			EndDialog(hDlg, TRUE);
 
-			DWORD iSel = SendDlgItemMessage(hDlg, IDD_GOTOLIST, LB_GETCURSEL, 0, 0);
+			iSel = (DWORD)SendDlgItemMessage(hDlg, IDD_GOTOLIST, LB_GETCURSEL, 0, 0);
 			if (iSel == LB_ERR)
 			{
 				if (GetDlgItemText(hDlg, IDD_GOTODIR, szPath, COUNTOF(szPath)) != 0)

--- a/src/wfinfo.c
+++ b/src/wfinfo.c
@@ -1536,7 +1536,7 @@ UpdateDriveListComplete(VOID)
       if (GetWindow(hwnd, GW_OWNER) || hwnd == hwndSearch)
          continue;
 
-      drive = GetWindowLongPtr(hwnd, GWL_TYPE);
+      drive = (DRIVE)GetWindowLongPtr(hwnd, GWL_TYPE);
 
       //
       // Invalidate cache to get real one in case the user reconnected
@@ -1586,7 +1586,7 @@ UpdateDriveListComplete(VOID)
    if (hwndDriveList)
    {
        SendMessage(hwndDriveList, WM_SETREDRAW, FALSE, 0);
-       CurSel = SendMessage(hwndDriveList, CB_GETCURSEL, 0, 0);
+       CurSel = (INT)SendMessage(hwndDriveList, CB_GETCURSEL, 0, 0);
        for (driveInd = 0; driveInd < cDrives; driveInd++)
        {
            if (aDriveInfo[rgiDrive[driveInd]].dwLines[ALTNAME_MULTI] != 1)
@@ -1818,7 +1818,7 @@ NetLoad(VOID)
 
          if (hwnd != hwndSearch && !GetWindow(hwnd, GW_OWNER)) {
 
-            drive = GetWindowLongPtr(hwnd, GWL_TYPE);
+            drive = (DRIVE)GetWindowLongPtr(hwnd, GWL_TYPE);
             DRIVESET(szPath, drive);
 
             if (!aDriveInfo[drive].bShareChkTried  &&

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -20,12 +20,6 @@
 
 #include "dbg.h"
 
-typedef VOID (APIENTRY *FNPENAPP)(WORD, BOOL);
-
-VOID (APIENTRY *lpfnRegisterPenApp)(WORD, BOOL);
-
-BYTE chPenReg[] = "RegisterPenApp";    // used in GetProcAddress call
-
 TCHAR szNTlanman[] = TEXT("ntlanman.dll");
 TCHAR szHelv[] = TEXT("MS Shell Dlg");
 /*
@@ -497,9 +491,9 @@ UINT  MapMenuPosToIDM(UINT pos)
         idm++;
     }
 
-    if (idm >= IDM_EXTENSIONS + iNumExtensions)
+    if (idm >= IDM_EXTENSIONS + (UINT)iNumExtensions)
     {
-        idm += MAX_EXTENSIONS - iNumExtensions;
+        idm += MAX_EXTENSIONS - (UINT)iNumExtensions;
     }
 
     return idm;
@@ -643,7 +637,7 @@ LoadBitmaps(VOID)
    //
    //  Skip the color table entries, if any
    //
-   lpBits += (1 << (lpBitmapInfo->biBitCount)) * sizeof(RGBQUAD);
+   lpBits += (DWORD)(1 << (lpBitmapInfo->biBitCount)) * sizeof(RGBQUAD);
 
    //
    // Create a color bitmap compatible with the display device
@@ -1062,10 +1056,6 @@ JAPANEND
 	if (OleInitialize(0) != NOERROR)
 		return FALSE;
 	
-   if (lpfnRegisterPenApp = (FNPENAPP)GetProcAddress((HANDLE)GetSystemMetrics(SM_PENWINDOWS), chPenReg))
-      (*lpfnRegisterPenApp)(1, TRUE);
-
-
    //
    // Remember the current directory.
    //
@@ -1595,9 +1585,6 @@ FreeFileManager()
 
    DocDestruct(ppDocBucket);
    DocDestruct(ppProgBucket);
-
-   if (lpfnRegisterPenApp)
-      (*lpfnRegisterPenApp)(1, FALSE);
 
    DeleteBitmaps();
 

--- a/src/wfloc.c
+++ b/src/wfloc.c
@@ -50,7 +50,7 @@ VOID InitLangList(HWND hCBox)
 
 VOID SaveLang(HWND hCBox)
 {
-    int iIndex = SendMessage(hCBox, CB_GETCURSEL, 0, 0);
+    int iIndex = (INT)SendMessage(hCBox, CB_GETCURSEL, 0, 0);
 
     if (iIndex == CB_ERR)
         return; // do nothing

--- a/src/wfmem.c
+++ b/src/wfmem.c
@@ -229,7 +229,7 @@ MemClone(LPXDTALINK lpStart)
    LPXDTALINK lpPrev;
    LPXDTALINK lpLink;
    LPXDTALINK lpNext;
-   DWORD_PTR dwSize;
+   SIZE_T dwSize;
 
 #ifdef TESTING
 // TESTING

--- a/src/wfmem.c
+++ b/src/wfmem.c
@@ -229,7 +229,7 @@ MemClone(LPXDTALINK lpStart)
    LPXDTALINK lpPrev;
    LPXDTALINK lpLink;
    LPXDTALINK lpNext;
-   DWORD dwSize;
+   DWORD_PTR dwSize;
 
 #ifdef TESTING
 // TESTING

--- a/src/wfprint.c
+++ b/src/wfprint.c
@@ -20,7 +20,7 @@
 DWORD
 PrintFile(HWND hwnd, LPTSTR szFile)
 {
-   DWORD          ret;
+   DWORD_PTR     ret;
    INT           iCurCount;
    INT           i;
    HCURSOR       hCursor;
@@ -40,7 +40,7 @@ PrintFile(HWND hwnd, LPTSTR szFile)
    // open the object
    //
    SetErrorMode(0);
-   ret = (DWORD)ShellExecute(hwnd, L"print", szFile, szNULL, szDir, SW_SHOWNORMAL);
+   ret = (DWORD_PTR)ShellExecute(hwnd, L"print", szFile, szNULL, szDir, SW_SHOWNORMAL);
    SetErrorMode(1);
 
    switch (ret) {
@@ -96,7 +96,7 @@ EPExit:
 
    SetCursor(hCursor);
 
-   return(ret);
+   return (DWORD)ret;
 }
 
 /*--------------------------------------------------------------------------*/

--- a/src/wfsearch.c
+++ b/src/wfsearch.c
@@ -686,7 +686,7 @@ SearchWndProc(
       return (LRESULT)DirGetSelection(NULL,
                                    hwnd,
                                    hwndLB,
-                                   wParam,
+                                   (INT)wParam,
                                    (BOOL *)lParam,
                                    NULL);
       break;
@@ -754,7 +754,7 @@ SearchWndProc(
       wParam &= ~CD_DONTSTEAL;
 
       if (wParam == CD_VIEW || wParam == CD_SEARCHFONT) {
-         dwNewView = GetWindowLongPtr(hwnd, GWL_VIEW);
+         dwNewView = (DWORD)GetWindowLongPtr(hwnd, GWL_VIEW);
 
          //
          // in case font changed, update maxExt
@@ -1032,7 +1032,7 @@ SearchWndProc(
    {
       LPDRAWITEMSTRUCT lpLBItem;
       PWORD pwTabs;
-      DWORD dwView = GetWindowLongPtr(hwnd, GWL_VIEW);
+      DWORD dwView = (DWORD)GetWindowLongPtr(hwnd, GWL_VIEW);
 
       lpLBItem = (LPDRAWITEMSTRUCT)lParam;
       iSel = lpLBItem->itemID;
@@ -1068,7 +1068,7 @@ SearchWndProc(
       }
 
       DrawItem(hwnd,
-               GetWindowLongPtr(hwnd, GWL_VIEW),
+               (DWORD)GetWindowLongPtr(hwnd, GWL_VIEW),
                (LPDRAWITEMSTRUCT)lParam,
                TRUE);
       break;
@@ -1369,7 +1369,7 @@ SearchDrive(LPVOID lpParameter)
                     (WORD *)GetWindowLongPtr(hwndSearch, GWL_TABARRAY),
                     maxExtLast,
                     0,
-                    GetWindowLongPtr(hwndSearch, GWL_VIEW));
+                    (DWORD)GetWindowLongPtr(hwndSearch, GWL_VIEW));
 
    SearchInfo.iRet = FillSearchLB(SearchInfo.hwndLB,
                                   SearchInfo.szSearch,

--- a/src/wftree.c
+++ b/src/wftree.c
@@ -116,7 +116,7 @@ CompactPath(HDC hDC, LPTSTR lpszPath, DWORD dx)
    GetTextExtentPoint32(hDC, lpFixed, lstrlen(lpFixed), &sizeF);
 
    while (TRUE) {
-      GetTextExtentPoint32(hDC, lpszPath, lpEnd - lpszPath, &sizeT);
+      GetTextExtentPoint32(hDC, lpszPath, (int)(lpEnd - lpszPath), &sizeT);
       len = sizeF.cx + sizeT.cx;
 
       if (bEllipsesIn)
@@ -288,7 +288,7 @@ SwitchDriveSelection(HWND hwndChild, BOOL bSelectToolbarDrive)
    DRIVEIND i, driveIndOld, driveIndOldFocus;
    RECT rc;
 
-   drive = GetWindowLongPtr(hwndChild, GWL_TYPE);
+   drive = (DRIVE)GetWindowLongPtr(hwndChild, GWL_TYPE);
 
    if (TYPE_SEARCH == drive) {
 
@@ -296,8 +296,8 @@ SwitchDriveSelection(HWND hwndChild, BOOL bSelectToolbarDrive)
    }
 
 
-   driveIndOld      = GetWindowLongPtr(hwndDriveBar, GWL_CURDRIVEIND);
-   driveIndOldFocus = GetWindowLongPtr(hwndDriveBar, GWL_CURDRIVEFOCUS);
+   driveIndOld      = (DRIVEIND)GetWindowLongPtr(hwndDriveBar, GWL_CURDRIVEIND);
+   driveIndOldFocus = (DRIVEIND)GetWindowLongPtr(hwndDriveBar, GWL_CURDRIVEFOCUS);
 
    for (i=0; i < cDrives; i++) {
       if (rgiDrive[i] == drive) {

--- a/src/wfutil.c
+++ b/src/wfutil.c
@@ -660,7 +660,7 @@ SetMDIWindowText(
             // if (wTextAttribs & TA_LOWERCASE)
             //    CharLower(szTemp);
 
-            drive = GetWindowLongPtr(hwnd, GWL_TYPE);
+            drive = (DWORD)GetWindowLongPtr(hwnd, GWL_TYPE);
             if (drive != -1) {     /* if not a search window */
                lstrcat(szTemp, SZ_SPACEDASHSPACE);
 
@@ -684,7 +684,7 @@ SetMDIWindowText(
    }
 
 
-   drive = GetWindowLongPtr(hwnd, GWL_TYPE);
+   drive = (DWORD)GetWindowLongPtr(hwnd, GWL_TYPE);
 
    uTitleLen = lstrlen(szTitle);
 
@@ -1417,7 +1417,7 @@ MyMessageBox(HWND hwnd, DWORD idTitle, DWORD idMessage, DWORD wStyle)
 DWORD
 ExecProgram(LPTSTR lpPath, LPTSTR lpParms, LPTSTR lpDir, BOOL bLoadIt, BOOL bRunAs)
 {
-  DWORD          ret;
+  DWORD_PTR     ret;
   INT           iCurCount;
   INT           i;
   HCURSOR       hCursor;
@@ -1447,7 +1447,7 @@ ExecProgram(LPTSTR lpPath, LPTSTR lpParms, LPTSTR lpDir, BOOL bLoadIt, BOOL bRun
      lpszTitle++;
 
   SetErrorMode(0);
-  ret = (DWORD) ShellExecute(hwndFrame, bRunAs ? L"runas" : NULL, lpPath, lpParms, lpDir, bLoadIt ? SW_SHOWMINNOACTIVE : SW_SHOWNORMAL);
+  ret = (DWORD_PTR) ShellExecute(hwndFrame, bRunAs ? L"runas" : NULL, lpPath, lpParms, lpDir, bLoadIt ? SW_SHOWMINNOACTIVE : SW_SHOWNORMAL);
 
   SetErrorMode(1);
 
@@ -1512,7 +1512,7 @@ EPExit:
 
   SetCursor(hCursor);
 
-  return ret;
+  return (DWORD)ret;
 }
 
 

--- a/src/winfile.c
+++ b/src/winfile.c
@@ -180,8 +180,8 @@ InitPopupMenus(UINT uMenus, HMENU hMenu, HWND hwndActive)
 
    hwndTree = HasTreeWindow(hwndActive);
    hwndDir = HasDirWindow(hwndActive);
-   dwSort = GetWindowLongPtr(hwndActive, GWL_SORT);
-   dwView = GetWindowLongPtr(hwndActive, GWL_VIEW);
+   dwSort = (DWORD)GetWindowLongPtr(hwndActive, GWL_SORT);
+   dwView = (DWORD)GetWindowLongPtr(hwndActive, GWL_VIEW);
 
    uMenuFlags = MF_BYCOMMAND | MF_ENABLED;
 


### PR DESCRIPTION
This is mainly casts to prevent x64 compiler warnings.  I looked at each case manually, mainly just preserving existing behavior.  Although it touches quite a bit, there's really a handful of patterns:

1. It looks like the code was bulk converted to use GetWindowLongPtr rather than GetWindowLong.  That implies truncating a 64 bit return value.  GetWindowLongPtr is needed for pointers or handles, but isn't needed for 32 bit values.  Nonetheless this change preserves them and casts the result, because I'll bet this conversion happened due to some other overzealous warning or analysis suggesting GetWindowLong isn't safe in 64 bit code.
2. There is arithmetic on 32 bit control IDs to map to extensions.  We shouldn't have more than 4 billion extensions.
3. SetStatusText can take either a string or a resource ID.  This leads to upcasting a 32 bit integer into a 64 bit pointer.  An additional 64 bit integer intermediate is used here.  The usage appears safe.
4. SendMessage and friends return a pointer sized return, but the meaning depends on the message type.  For many messages, truncation is appropriate.
5. strlen and friends return size_t.  (Aside: this has always annoyed me; just because a system has a 64 bit address space, doesn't mean any sane code wants to walk through 4Gb of memory looking for zero.)  In many cases we "know" strings can't be this long so the result can be casted.  Similarly, pointer arithmetic can be used to determine the length between two elements in a string, which we "know" should be less than 4Gb.
6. The current code assumes we can't have more than 2^31 items in a list, which seems like something we're unlikely to need any time soon.
7. ShellExecute and friends return a handle which can be 64 bit.  This code has two places where it translates success to zero, so the post-translated values cannot be 64 bit.
8. There's code for PenWindows which I'm fairly sure never worked in 32 bit.  In 16 bit, GetSystemMetrics can return a handle to the DLL, since the DLL once loaded is in the address space of every process.  In 32 bit, something has to actually map it, so GetSystemMetrics was documented to return zero/nonzero rather than the DLL base.  Also, RegisterPenApp was the 1.0 function which was replaced in 2.0 by SetPenAppFlags, and according to the 32 bit penwin.h, RegisterPenApp is not available as 32 bit.  If this ever did work, I'm curious about the NT 3.x pen enabled device it ran on - the intersection between those two seems minuscule at best.