### PR TITLE
Rename shall select all characters when it is a directory and contains a dot

### DIFF
--- a/src/wfdlgs2.c
+++ b/src/wfdlgs2.c
@@ -571,24 +571,37 @@ JAPANEND
       }
 
    case WM_NCACTIVATE:
-      if (IDM_RENAME == dwSuperDlgMode)
-      {
-		size_t ich1, ich2;
-		LPWSTR pchDot;
+      if (IDM_RENAME == dwSuperDlgMode) {
+         size_t ich1, ich2;
+         LPWSTR pchDot;
 
-		GetDlgItemText(hDlg, IDD_TO, szTo, COUNTOF(szTo));
-		ich1 = 0;
-		ich2 = wcslen(szTo);
-		pchDot = wcsrchr(szTo, '.');
-		if (pchDot != NULL)
-			ich2 = pchDot - szTo;
-		if (*szTo == '\"')
-		{
-			ich1 = 1;
-			if (pchDot == NULL)
-				ich2--;
-		}
-		SendDlgItemMessage(hDlg, IDD_TO, EM_SETSEL, ich1, ich2);
+         GetDlgItemText(hDlg, IDD_TO, szTo, COUNTOF(szTo));
+         ich1 = 0;
+         ich2 = wcslen(szTo);
+
+         // Search for extension
+         pchDot = wcsrchr(szTo, '.');
+         if (pchDot != NULL) {
+            TCHAR szTemp[MAXPATHLEN];
+            lstrcpy(szTemp, szTo);
+            QualifyPath(szTemp);
+
+            // Is this a file or directory
+            if (GetFileAttributes(szTemp) & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT)) {
+               if (szTo[ich2 - 1] == '\"')
+                  ich2--;
+            }
+            else {
+               ich2 = pchDot - szTo;
+            }
+         }
+         // Make sure we handle " properly with selection
+         if (*szTo == '\"') {
+            ich1 = 1;
+            if (pchDot == NULL)
+               ich2--;
+         }
+         SendDlgItemMessage(hDlg, IDD_TO, EM_SETSEL, ich1, ich2);
       }
       return FALSE;
       

--- a/src/wfdlgs2.c
+++ b/src/wfdlgs2.c
@@ -262,8 +262,6 @@ DoHelp:
 }
 
 
-#define RUN_LENGTH      MAXPATHLEN
-
 /*--------------------------------------------------------------------------*/
 /*                                                                          */
 /*  RunDlgProc() -                                                          */
@@ -279,7 +277,7 @@ RunDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
   LPTSTR pDir2;
   TCHAR szTemp[MAXPATHLEN];
   TCHAR szTemp2[MAXPATHLEN];
-  TCHAR sz3[RUN_LENGTH];
+  TCHAR sz3[MAXPATHLEN];
 
   UNREFERENCED_PARAMETER(lParam);
 
@@ -587,7 +585,7 @@ JAPANEND
             QualifyPath(szTemp);
 
             // Is this a file or directory
-            if (GetFileAttributes(szTemp) & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT)) {
+            if (GetFileAttributes(szTemp) & FILE_ATTRIBUTE_DIRECTORY) {
                if (szTo[ich2 - 1] == '\"')
                   ich2--;
             }


### PR DESCRIPTION
### Problem
Renaming a directory with . in it assumes the characters behind . are an extension, and does not select them

### How to test
Start   [TestRenameSelectiont.zip](https://github.com/microsoft/winfile/files/8720358/TestRenameSelectiont.zip) from an administrative command prompt in your e.g. temp directory. 

In the directory or file pane navigate to bla.000.000.000 and press F2. All characters are selected now
Do this also for bla.000.000.000 - symlink. Also all characters are selected
When selecting bla.000.000.000.dll, which is a file, only the characters before the extension are selected as in the previous version.