### PR TITLE
* Goto Cache Improvements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ selecting one changes to that directory.  Default = c:\. Confgigure via Winfile.
 15. View command has a new option to sort by date forward (oldest on top);
 normal date sorting is newest on top
 16. CTRL + ENTER executes associated files as administrator
+19. The delimiters for splitting words for the GotoCache can be configured via Winfile.ini[Settings]GotoCachePunctuation. The default is - _.
 
 You can read the code for more details.
 

--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -427,6 +427,7 @@ BOOL BuildDirectoryBagOValues(BagOValues<PDNODE> *pbov, vector<PDNODE> *pNodes, 
 
 			default:
 				bFollow = FALSE;
+				break;
 			}
 		}
 		else {

--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -426,7 +426,7 @@ BOOL BuildDirectoryBagOValues(BagOValues<PDNODE> *pbov, vector<PDNODE> *pNodes, 
 				break;
 
 			default:
-				BOOL bFollow = FALSE;
+				bFollow = FALSE;
 			}
 		}
 		else {

--- a/src/wfinfo.c
+++ b/src/wfinfo.c
@@ -1803,9 +1803,6 @@ NetLoad(VOID)
    SetEvent(hEventAcledit);
    bNetAcleditDone = TRUE;
 
-   if (hNtdll)
-      FreeLibrary(hNtdll);
-
    //
    // We need to check both, since this is a sharing thing,
    // but the api is in network.

--- a/src/wfinfo.c
+++ b/src/wfinfo.c
@@ -1803,6 +1803,9 @@ NetLoad(VOID)
    SetEvent(hEventAcledit);
    bNetAcleditDone = TRUE;
 
+   if (hNtdll)
+      FreeLibrary(hNtdll);
+
    //
    // We need to check both, since this is a sharing thing,
    // but the api is in network.

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -1313,7 +1313,7 @@ JAPANEND
    win.rc.bottom -= win.rc.top;
 
    // We need to know about all reaprse tags
-   hNtdll = LoadLibrary(L"ntdll.dll");
+   hNtdll = GetModuleHandle(L"ntdll.dll");
    if (hNtdll)
    {
       pfnRtlSetProcessPlaceholderCompatibilityMode = (RtlSetProcessPlaceholderCompatibilityMode_t)GetProcAddress(hNtdll, "RtlSetProcessPlaceholderCompatibilityMode");

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -1313,7 +1313,7 @@ JAPANEND
    win.rc.bottom -= win.rc.top;
 
    // We need to know about all reaprse tags
-   hNtdll = GetModuleHandle(L"ntdll.dll");
+   hNtdll = GetModuleHandle(NTDLL_DLL);
    if (hNtdll)
    {
       pfnRtlSetProcessPlaceholderCompatibilityMode = (RtlSetProcessPlaceholderCompatibilityMode_t)GetProcAddress(hNtdll, "RtlSetProcessPlaceholderCompatibilityMode");

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -1312,6 +1312,14 @@ JAPANEND
    win.rc.right -= win.rc.left;
    win.rc.bottom -= win.rc.top;
 
+   // We need to know about all reaprse tags
+   hNtdll = LoadLibrary(L"ntdll.dll");
+   if (hNtdll)
+   {
+      pfnRtlSetProcessPlaceholderCompatibilityMode = (RtlSetProcessPlaceholderCompatibilityMode_t)GetProcAddress(hNtdll, "RtlSetProcessPlaceholderCompatibilityMode");
+      if (pfnRtlSetProcessPlaceholderCompatibilityMode)
+         pfnRtlSetProcessPlaceholderCompatibilityMode(PHCM_EXPOSE_PLACEHOLDERS);
+   }
 
    //
    // Check to see if another copy of winfile is running.  If

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -1006,6 +1006,7 @@ BOOL LoadUxTheme(VOID);
 #define MPR_DLL      TEXT("mpr.dll")
 #define NTSHRUI_DLL  TEXT("Ntshrui.dll")
 #define ACLEDIT_DLL  TEXT("acledit.dll")
+#define NTDLL_DLL    TEXT("ntdll.dll")
 
 #define WAITNET()      WaitLoadEvent(TRUE)
 #define WAITACLEDIT()  WaitLoadEvent(FALSE)
@@ -1090,6 +1091,7 @@ Extern HANDLE hVersion             EQ( NULL );
 Extern HANDLE hMPR                 EQ( NULL );
 Extern HANDLE hNtshrui             EQ( NULL );
 Extern HANDLE hAcledit             EQ( NULL );
+Extern HANDLE hNtdll               EQ (NULL );
 
 
 //--------------------------------------------------------------------------
@@ -1183,6 +1185,9 @@ Extern TCHAR        szUILanguage[]          EQ( TEXT("UILanguage") );
 Extern TCHAR        szEditorPath[]          EQ( TEXT("EditorPath"));
 Extern TCHAR        szMirrorContent[]       EQ( TEXT("MirrorContent") );
 Extern TCHAR        szCachedPath[]          EQ( TEXT("CachedPath"));
+Extern TCHAR        szCachedRootLower[MAXPATHLEN];
+Extern TCHAR        szGotoCachePunctuation[] EQ(TEXT("GotoCachePunctuation"));
+Extern TCHAR        szPunctuation[MAXPATHLEN];
 
 Extern TCHAR        szMinOnRun[]            EQ( TEXT("MinOnRun") );
 Extern TCHAR        szIndexOnLaunch[]       EQ( TEXT("IndexOnLaunch") );
@@ -1370,6 +1375,13 @@ Extern   SEARCH_INFO SearchInfo;
 
 // this value is an index into dwMenuIDs and used to workaround a bug
 #define MHPOP_CURRENT 2
+
+Extern CHAR PHCM_EXPOSE_PLACEHOLDERS    EQ(2);
+typedef NTSYSAPI CHAR (*RtlSetProcessPlaceholderCompatibilityMode_t)(
+   CHAR aMode
+   );
+RtlSetProcessPlaceholderCompatibilityMode_t pfnRtlSetProcessPlaceholderCompatibilityMode;
+
 
 #ifdef _GLOBALS
    DWORD dwMenuIDs[] = {

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -1185,7 +1185,6 @@ Extern TCHAR        szUILanguage[]          EQ( TEXT("UILanguage") );
 Extern TCHAR        szEditorPath[]          EQ( TEXT("EditorPath"));
 Extern TCHAR        szMirrorContent[]       EQ( TEXT("MirrorContent") );
 Extern TCHAR        szCachedPath[]          EQ( TEXT("CachedPath"));
-Extern TCHAR        szCachedRootLower[MAXPATHLEN];
 Extern TCHAR        szGotoCachePunctuation[] EQ(TEXT("GotoCachePunctuation"));
 Extern TCHAR        szPunctuation[MAXPATHLEN];
 


### PR DESCRIPTION
### Problems
The Goto Cache had a few little problems
* It followed all reparse points, which could drive it into a reparse - loop. 
* Items were enumerated many times when they were behind reparse points
* The punctuation was limited to \<blank\> See #296
* The punctuation could not be configured

### Changes
* The punctuation is now extended to "- _."
* The punctuation can be configured via Winfile.ini[Settings]GotoCachePunctuation
* The Goto Cache now only follows 
**so called 'outer' reparse points, but drops so called 'inner' reparse points, because these files are anyhow reached via normal file enumeration.
** Onedrive. This PR also works for OneDrive and opposite to #132 has no limitations.

### General
What is a 'inner'/ 'outer' reparse point: 
* With respect to a root, e.g. c:\foo a reparse point is called 'inner' if it points to a location below the root, e.g. c:\foo\bla\reparse -> c:\foo\bla\reparse_dest
* With respect to a root, e.g. c:\foo a reparse point is called 'outer' if it points to a location outside the root, e.g. c:\foo\bla\reparse -> c:\bla\dest


