### PR TITLE
TypeAhead Fix

### DIFF
--- a/src/wfutil.c
+++ b/src/wfutil.c
@@ -1571,6 +1571,7 @@ BOOL TypeAheadString(WCHAR ch, LPWSTR szT)
 {
    static DWORD tick64 = 0;
    static WCHAR rgchTA[MAXPATHLEN] = { '\0' };
+   static BOOL sameChar = TRUE;
    DWORD tickT;
    size_t ich;
 
@@ -1586,20 +1587,26 @@ BOOL TypeAheadString(WCHAR ch, LPWSTR szT)
 
    // if out of space or more than .5s since last char, start over
    if (tickT - tick64 > 500 || ich > MAXPATHLEN - 2)
+   {
       ich = 0;
+      sameChar = TRUE;
+   }
 
    rgchTA[ich] = ch;
    rgchTA[ich + 1] = '\0';
 
    tick64 = tickT;
 
-   if (rgchTA[0] == ch) {
-      // If one pressed the same character as the first anyhow jump ahead by one
+   if (rgchTA[0] == ch && TRUE == sameChar) {
+      // Same consecutive character as the first was pressed so jump ahead by one
       szT[0] = ch;
       szT[1] = '\0';
 
       return FALSE;
    }
+   else
+      // not the same character as the first
+      sameChar = FALSE;
 
    lstrcpy(szT, rgchTA);
 

--- a/src/wfutil.c
+++ b/src/wfutil.c
@@ -1570,7 +1570,11 @@ IsBucketFile(LPTSTR lpszPath, PPDOCBUCKET ppBucket)
 BOOL TypeAheadString(WCHAR ch, LPWSTR szT)
 {
    static DWORD tick64 = 0;
+   
+   // Ringbuffer for typed chracters
    static WCHAR rgchTA[MAXPATHLEN] = { '\0' };
+   
+   // When typing characters all characters so far are the same
    static BOOL sameChar = TRUE;
    DWORD tickT;
    size_t ich;
@@ -1604,9 +1608,10 @@ BOOL TypeAheadString(WCHAR ch, LPWSTR szT)
 
       return FALSE;
    }
-   else
+   else {
       // not the same character as the first
       sameChar = FALSE;
+   }
 
    lstrcpy(szT, rgchTA);
 


### PR DESCRIPTION
### General
With #290 TypeAhead was fixed, but we all overlooked one use-case

### Problem
Assume you have the following files in a directory

```
as
bla
san
system
syxsser
zzz
```

The [attached .bat file](https://github.com/microsoft/winfile/files/8866981/TypeAHead.zip) creates such a situation.
- Select 'bla' in the right pane
- Type 's' 'y' 's'
- The cursor is on 'syxsser' which is **not correct**. It should be on 'system'

### About the changes
With #290 we overlooked, that only *consecutive same* characters shall move the cursor ahead by one. The #290 solution also moves ahead by one, if any character typed within a word is the same as the first, but other characters are in between.

I now cross checked the fixed behavior with explorer and it is exactly the same.

