### PR TITLE
Wrapper for GetFileAttributes() with Wow64DisableWow64FsRedirection()

### DIFF
--- a/src/lfn.c
+++ b/src/lfn.c
@@ -210,7 +210,7 @@ WFFindClose(LPLFNDTA lpFind)
 BOOL
 WFIsDir(LPTSTR lpDir)
 {
-   DWORD attr = GetFileAttributes(lpDir);
+   DWORD attr = WFGetFileAttributes(lpDir);
 
    if (attr == INVALID_FILE_ATTRIBUTES)
       return FALSE;
@@ -586,4 +586,21 @@ WFMove(LPTSTR pszFrom, LPTSTR pszTo, PBOOL pbErrorOnDest, BOOL bSilent)
    return dwRet;
 }
 
+/* WFGetFileAttributes -
+ *
+ * returns:
+ *      Attributes for a file/directory
+ */
 
+DWORD
+WFGetFileAttributes(LPTSTR lpName)
+{
+   DWORD attrib;
+   PVOID oldValue;
+
+   Wow64DisableWow64FsRedirection(&oldValue);
+   attrib = GetFileAttributes(lpName);
+   Wow64RevertWow64FsRedirection(oldValue);
+
+   return attrib;
+}

--- a/src/treectl.c
+++ b/src/treectl.c
@@ -160,7 +160,7 @@ GetTreePath(PDNODE pNode, register LPTSTR szDest)
 VOID
 SetNodeAttribs(PDNODE pNode, LPTSTR szPath)
 {
-   pNode->dwAttribs = GetFileAttributes(szPath);
+   pNode->dwAttribs = WFGetFileAttributes(szPath);
    if (INVALID_FILE_ATTRIBUTES == pNode->dwAttribs) {
       pNode->dwAttribs = 0;
    }

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -308,7 +308,7 @@ ChangeFileSystem(
          // Are we renaming a directory?
          lstrcpy(szTemp, szTo);
 
-         if (GetFileAttributes(szTemp) & ATTR_DIR)
+         if (WFGetFileAttributes(szTemp) & ATTR_DIR)
          {
             for (hwnd = GetWindow(hwndMDIClient, GW_CHILD);
                  hwnd;

--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -770,7 +770,7 @@ DiskNotThere:
 
    case ERROR_INVALID_PARAMETER:
 
-      // Handle INVALID PARAMETER from GetDriveDirectory from GetFileAttributes
+      // Handle INVALID PARAMETER from GetDriveDirectory from WFGetFileAttributes
       dwError = ERROR_NOT_READY;
       break;
 
@@ -2452,7 +2452,7 @@ TRY_COPY_AGAIN:
             lstrcat(szDestAlt, szExtension);
             
             // We only do a one level '- Copy' postfixing, and do intentionally not go for a '- Copy (n)' postfix
-            if (INVALID_FILE_ATTRIBUTES == GetFileAttributes(szDestAlt)) {
+            if (INVALID_FILE_ATTRIBUTES == WFGetFileAttributes(szDestAlt)) {
                lstrcpy(szDest, szDestAlt);
                bSameFile = FALSE;
             } else {
@@ -2512,7 +2512,7 @@ TRY_COPY_AGAIN:
                //
                //  Save the attributes, since ConfirmDialog may change them.
                //
-               dwAttr = GetFileAttributes(szDest);
+               dwAttr = WFGetFileAttributes(szDest);
 
                // we need to check if we are trying to copy a file
                // over a directory and give a reasonable error message
@@ -2809,7 +2809,7 @@ SkipMKDir:
          //
          // Tuck away the attribs in case we fail.
          //
-         dwAttr = GetFileAttributes(szSource);
+         dwAttr = WFGetFileAttributes(szSource);
 
          WFSetAttr(szSource, FILE_ATTRIBUTE_NORMAL);
 
@@ -2955,7 +2955,7 @@ DoMoveRename:
          //
          //  Save the attributes, since ConfirmDialog may change them.
          //
-         dwAttr = GetFileAttributes(szSource);
+         dwAttr = WFGetFileAttributes(szSource);
 
          // Confirm the rename
 
@@ -3088,7 +3088,7 @@ RenameMoveDone:
          //
          //  Save the attributes, since ConfirmDialog may change them.
          //
-         dwAttr = GetFileAttributes(szSource);
+         dwAttr = WFGetFileAttributes(szSource);
 
          // Confirm the delete first
 

--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -754,7 +754,7 @@ InvalidDirectory:
 
                // Check if it is a Reparse Point
                lpTemp[0] = '\0';
-               DWORD attr = GetFileAttributes(szPath);
+               DWORD attr = WFGetFileAttributes(szPath);
                lpTemp[0] = CHAR_BACKSLASH;
                if (attr & ATTR_REPARSE_POINT) {
                   // For dead Reparse Points just tell that the directory could not be read

--- a/src/wfdlgs2.c
+++ b/src/wfdlgs2.c
@@ -1767,7 +1767,7 @@ AttribsDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 
             QualifyPath(szName);
 
-            dwAttribs = GetFileAttributes(szName);
+            dwAttribs = WFGetFileAttributes(szName);
 
             if (dwAttribs == INVALID_FILE_ATTRIBUTES)
                goto AttributeError;

--- a/src/wffile.c
+++ b/src/wffile.c
@@ -744,7 +744,7 @@ BOOL WFCheckCompress(
     //
     //  Get the file attributes.
     //
-    dwAttribs = GetFileAttributes(szNameSpec);
+    dwAttribs = WFGetFileAttributes(szNameSpec);
 
     //
     //  Determine if ATTR_COMPRESSED is changing state.
@@ -1232,7 +1232,7 @@ DoCompressError:
                 //
                 lstrcpy(DirectorySpecEnd, FindData.cFileName);
 
-                if (GetFileAttributes(DirectorySpec) & ATTR_COMPRESSED)
+                if (WFGetFileAttributes(DirectorySpec) & ATTR_COMPRESSED)
                 {
                     //
                     //  Already compressed, so just get the next file.
@@ -1541,7 +1541,7 @@ DoUncompressError:
                 //
                 lstrcpy(DirectorySpecEnd, FindData.cFileName);
 
-                if (!(GetFileAttributes(DirectorySpec) & ATTR_COMPRESSED))
+                if (!(WFGetFileAttributes(DirectorySpec) & ATTR_COMPRESSED))
                 {
                     //
                     //  Already uncompressed, so get the next file.

--- a/src/wfutil.c
+++ b/src/wfutil.c
@@ -242,7 +242,7 @@ BOOL  GetDriveDirectory(INT iDrive, LPTSTR pszDir)
         drvstr[1] = ('\0');
     }
 
-	if (GetFileAttributes(drvstr) == INVALID_FILE_ATTRIBUTES)
+	if (WFGetFileAttributes(drvstr) == INVALID_FILE_ATTRIBUTES)
 		return FALSE;
 
 //	if (!CheckDirExists(drvstr))

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -648,6 +648,7 @@ DWORD WFRemove(LPTSTR pszFile);
 DWORD WFMove(LPTSTR pszFrom, LPTSTR pszTo, PBOOL pbErrorOnDest, BOOL bSilent);
 DWORD WFCopyIfSymlink(LPTSTR pszFrom, LPTSTR pszTo, DWORD dwFlags, DWORD dwNotification);
 DWORD DecodeReparsePoint(LPCWSTR szMyFile, LPWSTR szDest, DWORD cwcDest);
+DWORD WFGetFileAttributes(LPTSTR lpName);
 
 
 // TREECTL.C


### PR DESCRIPTION
Wow64DisableWow64FsRedirection is not used in all file access
This PR provides a Wrapper WFGetFileAttributes, which does this