### PR TITLE
Wow64 wrappers for all FS API calls

### DIFF
--- a/src/Winfile.vcxproj
+++ b/src/Winfile.vcxproj
@@ -400,6 +400,7 @@
     <ClCompile Include="wfsearch.c" />
     <ClCompile Include="wftree.c" />
     <ClCompile Include="wfutil.c" />
+    <ClCompile Include="wfwow.c" />
     <ClCompile Include="winfile.c" />
     <ClCompile Include="wnetcaps.c" />
   </ItemGroup>

--- a/src/treectl.c
+++ b/src/treectl.c
@@ -160,7 +160,7 @@ GetTreePath(PDNODE pNode, register LPTSTR szDest)
 VOID
 SetNodeAttribs(PDNODE pNode, LPTSTR szPath)
 {
-   pNode->dwAttribs = GetFileAttributes(szPath);
+   pNode->dwAttribs = WfWowGetFileAttributes(szPath);
    if (INVALID_FILE_ATTRIBUTES == pNode->dwAttribs) {
       pNode->dwAttribs = 0;
    }

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -308,7 +308,7 @@ ChangeFileSystem(
          // Are we renaming a directory?
          lstrcpy(szTemp, szTo);
 
-         if (GetFileAttributes(szTemp) & ATTR_DIR)
+         if (WfWowGetFileAttributes(szTemp) & ATTR_DIR)
          {
             for (hwnd = GetWindow(hwndMDIClient, GW_CHILD);
                  hwnd;
@@ -1375,7 +1375,7 @@ AppCommandProc(register DWORD id)
 				sei.lpDirectory = szPath;
 			 }
 
-			 ShellExecuteEx(&sei);
+			 WfWowShellExecuteEx(&sei);
 		 }
          else if (count > 1)
             DialogBox(hAppInstance, (LPTSTR) MAKEINTRESOURCE(MULTIPLEATTRIBSDLG), hwndFrame, AttribsDlgProc);

--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -2452,7 +2452,7 @@ TRY_COPY_AGAIN:
             lstrcat(szDestAlt, szExtension);
             
             // We only do a one level '- Copy' postfixing, and do intentionally not go for a '- Copy (n)' postfix
-            if (INVALID_FILE_ATTRIBUTES == GetFileAttributes(szDestAlt)) {
+            if (INVALID_FILE_ATTRIBUTES == WfWowGetFileAttributes(szDestAlt)) {
                lstrcpy(szDest, szDestAlt);
                bSameFile = FALSE;
             } else {
@@ -2512,7 +2512,7 @@ TRY_COPY_AGAIN:
                //
                //  Save the attributes, since ConfirmDialog may change them.
                //
-               dwAttr = GetFileAttributes(szDest);
+               dwAttr = WfWowGetFileAttributes(szDest);
 
                // we need to check if we are trying to copy a file
                // over a directory and give a reasonable error message
@@ -2600,7 +2600,7 @@ TRY_COPY_AGAIN:
                          //
                          if (ret)
                          {
-                             SetFileAttributes(szDest, dwAttr);
+                             WfWowSetFileAttributes(szDest, dwAttr);
                          }
                      }
 
@@ -2809,7 +2809,7 @@ SkipMKDir:
          //
          // Tuck away the attribs in case we fail.
          //
-         dwAttr = GetFileAttributes(szSource);
+         dwAttr = WfWowGetFileAttributes(szSource);
 
          WFSetAttr(szSource, FILE_ATTRIBUTE_NORMAL);
 
@@ -2880,8 +2880,8 @@ SkipMKDir:
             // NOTE:  Must first make sure the attributes are clear so that
             //        the delete will always succeed.
             //
-            SetFileAttributes(szDest, FILE_ATTRIBUTE_NORMAL);
-            DeleteFile(szDest);
+            WfWowSetFileAttributes(szDest, FILE_ATTRIBUTE_NORMAL);
+            WfWowDeleteFile(szDest);
 
             //
             // Show retry popup.
@@ -2955,7 +2955,7 @@ DoMoveRename:
          //
          //  Save the attributes, since ConfirmDialog may change them.
          //
-         dwAttr = GetFileAttributes(szSource);
+         dwAttr = WfWowGetFileAttributes(szSource);
 
          // Confirm the rename
 
@@ -3066,7 +3066,7 @@ DoMoveRename:
                 //  Reset the attributes on the source file, since they
                 //  may have been changed by ConfirmDialog.
                 //
-                SetFileAttributes(szSource, dwAttr);
+                WfWowSetFileAttributes(szSource, dwAttr);
             }
 
             if (pCopyInfo->bUserAbort)
@@ -3088,7 +3088,7 @@ RenameMoveDone:
          //
          //  Save the attributes, since ConfirmDialog may change them.
          //
-         dwAttr = GetFileAttributes(szSource);
+         dwAttr = WfWowGetFileAttributes(szSource);
 
          // Confirm the delete first
 
@@ -3131,7 +3131,7 @@ RenameMoveDone:
          //
          if (ret)
          {
-             SetFileAttributes(szSource, dwAttr);
+             WfWowSetFileAttributes(szSource, dwAttr);
          }
 
          break;
@@ -3387,7 +3387,7 @@ Error:
 DWORD
 FileRemove(LPTSTR pSpec)
 {
-   if (DeleteFile(pSpec))
+   if (WfWowDeleteFile(pSpec))
       return (DWORD)0;
    else
       return GetLastError();
@@ -3404,7 +3404,7 @@ FileMove(LPTSTR pFrom, LPTSTR pTo, PBOOL pbErrorOnDest, BOOL bSilent)
    *pbErrorOnDest = FALSE;
 
 TryAgain:
-    if (MoveFile((LPTSTR)pFrom, (LPTSTR)pTo))
+    if (WfWowMoveFile((LPTSTR)pFrom, (LPTSTR)pTo))
         result = 0;
     else
         result = GetLastError();

--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -754,7 +754,7 @@ InvalidDirectory:
 
                // Check if it is a Reparse Point
                lpTemp[0] = '\0';
-               DWORD attr = GetFileAttributes(szPath);
+               DWORD attr = WfWowGetFileAttributes(szPath);
                lpTemp[0] = CHAR_BACKSLASH;
                if (attr & ATTR_REPARSE_POINT) {
                   // For dead Reparse Points just tell that the directory could not be read
@@ -1168,7 +1168,7 @@ DWORD DecodeReparsePoint(LPCWSTR szFullPath, LPWSTR szDest, DWORD cwcDest)
 	DWORD reparseTag;
 	BOOL bRP;
 
-	hFile = CreateFile(szFullPath, FILE_READ_EA, FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+	hFile = WfWowCreateFile(szFullPath, FILE_READ_EA, FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
 	if (hFile == INVALID_HANDLE_VALUE)
 		return IO_REPARSE_TAG_RESERVED_ZERO;
 		

--- a/src/wfdlgs2.c
+++ b/src/wfdlgs2.c
@@ -589,7 +589,7 @@ JAPANEND
             QualifyPath(szTemp);
 
             // Is this a file or directory
-            if (GetFileAttributes(szTemp) & FILE_ATTRIBUTE_DIRECTORY) {
+            if (WfWowGetFileAttributes(szTemp) & FILE_ATTRIBUTE_DIRECTORY) {
                if (szTo[ich2 - 1] == '\"')
                   ich2--;
             }
@@ -1402,7 +1402,7 @@ FullPath:
       {
          if ((bFileCompression) && (dwAttribsOn & ATTR_COMPRESSED))
          {
-            qCSize.LowPart = GetCompressedFileSize(szName, &(qCSize.HighPart));
+            qCSize.LowPart = WfWowGetCompressedFileSize(szName, &(qCSize.HighPart));
             PutSize(&qCSize, szNum);
             wsprintf(szTemp, szSBytes, szNum);
             SetDlgItemText(hDlg, IDD_CSIZE, szTemp);
@@ -1778,7 +1778,7 @@ AttribsDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 
             QualifyPath(szName);
 
-            dwAttribs = GetFileAttributes(szName);
+            dwAttribs = WfWowGetFileAttributes(szName);
 
             if (dwAttribs == INVALID_FILE_ATTRIBUTES)
                goto AttributeError;

--- a/src/wfdrop.c
+++ b/src/wfdrop.c
@@ -187,7 +187,7 @@ static HRESULT StreamToFile(IStream *stream, TCHAR *szFile)
     HRESULT hr;
 	HANDLE hFile;
 
-    hFile = CreateFile( szFile,
+    hFile = WfWowCreateFile( szFile,
           FILE_READ_DATA | FILE_WRITE_DATA,
           FILE_SHARE_READ | FILE_SHARE_WRITE,
           NULL,
@@ -210,7 +210,7 @@ static HRESULT StreamToFile(IStream *stream, TCHAR *szFile)
         } while (S_OK == hr && bytes_written != 0);
         CloseHandle(hFile);
 		if (FAILED(hr))
-			DeleteFile(szFile);
+			WfWowDeleteFile(szFile);
 		else
 			hr = S_OK;
     }

--- a/src/wffile.c
+++ b/src/wffile.c
@@ -121,8 +121,8 @@ DWORD MKDir(
    DWORD dwErr = ERROR_SUCCESS;
 
    if ((pSrc && *pSrc) ?
-         CreateDirectoryEx(pSrc, pName, NULL) :
-         CreateDirectory(pName, NULL)) {
+         WfWowCreateDirectoryEx(pSrc, pName, NULL) :
+         WfWowCreateDirectory(pName, NULL)) {
       ChangeFileSystem(FSC_MKDIR, pName, NULL);
    } else {
       dwErr = GetLastError();
@@ -149,7 +149,7 @@ DWORD RMDir(
 {
    DWORD dwErr = 0;
 
-   if (RemoveDirectory(pName))
+   if (WfWowRemoveDirectory(pName))
    {
       ChangeFileSystem(FSC_RMDIR, pName, NULL);
    }
@@ -182,7 +182,7 @@ BOOL WFSetAttr(
    //
    dwAttr = dwAttr & ~(ATTR_COMPRESSED | ATTR_ENCRYPTED);
 
-   bRet = SetFileAttributes(lpFile, dwAttr);
+   bRet = WfWowSetFileAttributes(lpFile, dwAttr);
 
    if (bRet)
    {
@@ -744,7 +744,7 @@ BOOL WFCheckCompress(
     //
     //  Get the file attributes.
     //
-    dwAttribs = GetFileAttributes(szNameSpec);
+    dwAttribs = WfWowGetFileAttributes(szNameSpec);
 
     //
     //  Determine if ATTR_COMPRESSED is changing state.
@@ -1054,8 +1054,8 @@ BOOL CompressFile(
     //
     FileSize.LowPart = FindData->nFileSizeLow;
     FileSize.HighPart = FindData->nFileSizeHigh;
-    CompressedSize.LowPart = GetCompressedFileSize( FileSpec,
-                                                    &(CompressedSize.HighPart) );
+    CompressedSize.LowPart = WfWowGetCompressedFileSize( FileSpec,
+                                                         &(CompressedSize.HighPart) );
 
     //
     //  Increment the running total.
@@ -1187,7 +1187,7 @@ DoCompressError:
     //
     lstrcpy(DirectorySpecEnd, FileSpec);
 
-    if ((FindHandle = FindFirstFile(DirectorySpec, &FindData)) != INVALID_HANDLE_VALUE)
+    if ((FindHandle = WfWowFindFirstFile(DirectorySpec, &FindData)) != INVALID_HANDLE_VALUE)
     {
         do
         {
@@ -1232,7 +1232,7 @@ DoCompressError:
                 //
                 lstrcpy(DirectorySpecEnd, FindData.cFileName);
 
-                if (GetFileAttributes(DirectorySpec) & ATTR_COMPRESSED)
+                if (WfWowGetFileAttributes(DirectorySpec) & ATTR_COMPRESSED)
                 {
                     //
                     //  Already compressed, so just get the next file.
@@ -1294,7 +1294,7 @@ CompressFileError:
                 }
             }
 
-        } while (FindNextFile(FindHandle, &FindData));
+        } while (WfWowFindNextFile(FindHandle, &FindData));
 
         FindClose(FindHandle);
 
@@ -1312,7 +1312,7 @@ CompressFileError:
         //
         lstrcpy(DirectorySpecEnd, SZ_STAR);
 
-        if ((FindHandle = FindFirstFile(DirectorySpec, &FindData)) != INVALID_HANDLE_VALUE)
+        if ((FindHandle = WfWowFindFirstFile(DirectorySpec, &FindData)) != INVALID_HANDLE_VALUE)
         {
             do
             {
@@ -1344,7 +1344,7 @@ CompressFileError:
                     }
                 }
 
-            } while (FindNextFile(FindHandle, &FindData));
+            } while (WfWowFindNextFile(FindHandle, &FindData));
 
             FindClose(FindHandle);
         }
@@ -1513,7 +1513,7 @@ DoUncompressError:
     //
     lstrcpy(DirectorySpecEnd, FileSpec);
 
-    if ((FindHandle = FindFirstFile(DirectorySpec, &FindData)) != INVALID_HANDLE_VALUE)
+    if ((FindHandle = WfWowFindFirstFile(DirectorySpec, &FindData)) != INVALID_HANDLE_VALUE)
     {
         do
         {
@@ -1541,7 +1541,7 @@ DoUncompressError:
                 //
                 lstrcpy(DirectorySpecEnd, FindData.cFileName);
 
-                if (!(GetFileAttributes(DirectorySpec) & ATTR_COMPRESSED))
+                if (!(WfWowGetFileAttributes(DirectorySpec) & ATTR_COMPRESSED))
                 {
                     //
                     //  Already uncompressed, so get the next file.
@@ -1603,7 +1603,7 @@ UncompressFileError:
                 }
             }
 
-        } while (FindNextFile(FindHandle, &FindData));
+        } while (WfWowFindNextFile(FindHandle, &FindData));
 
         FindClose(FindHandle);
 
@@ -1621,7 +1621,7 @@ UncompressFileError:
         //
         lstrcpy(DirectorySpecEnd, SZ_STAR);
 
-        if ((FindHandle = FindFirstFile(DirectorySpec, &FindData)) != INVALID_HANDLE_VALUE)
+        if ((FindHandle = WfWowFindFirstFile(DirectorySpec, &FindData)) != INVALID_HANDLE_VALUE)
         {
             do
             {
@@ -1653,7 +1653,7 @@ UncompressFileError:
                     }
                 }
 
-            } while (FindNextFile(FindHandle, &FindData));
+            } while (WfWowFindNextFile(FindHandle, &FindData));
 
             FindClose(FindHandle);
         }
@@ -1900,13 +1900,13 @@ BOOL OpenFileForCompress(
     //
     //  Try to open the file - READ_DATA | WRITE_DATA.
     //
-    if ((*phFile = CreateFile( szFile,
-                               FILE_READ_DATA | FILE_WRITE_DATA,
-                               FILE_SHARE_READ | FILE_SHARE_WRITE,
-                               NULL,
-                               OPEN_EXISTING,
-                               FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_SEQUENTIAL_SCAN,
-                               NULL )) != INVALID_HANDLE_VALUE)
+    if ((*phFile = WfWowCreateFile( szFile,
+                                    FILE_READ_DATA | FILE_WRITE_DATA,
+                                    FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                    NULL,
+                                    OPEN_EXISTING,
+                                    FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_SEQUENTIAL_SCAN,
+                                    NULL )) != INVALID_HANDLE_VALUE)
     {
         //
         //  Successfully opened the file.
@@ -1922,13 +1922,13 @@ BOOL OpenFileForCompress(
     //
     //  Try to open the file - READ_ATTRIBUTES | WRITE_ATTRIBUTES.
     //
-    if ((hAttr = CreateFile( szFile,
-                             FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES,
-                             FILE_SHARE_READ | FILE_SHARE_WRITE,
-                             NULL,
-                             OPEN_EXISTING,
-                             FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_SEQUENTIAL_SCAN,
-                             NULL )) == INVALID_HANDLE_VALUE)
+    if ((hAttr = WfWowCreateFile( szFile,
+                                  FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES,
+                                  FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                  NULL,
+                                  OPEN_EXISTING,
+                                  FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_SEQUENTIAL_SCAN,
+                                  NULL )) == INVALID_HANDLE_VALUE)
     {
         return (FALSE);
     }
@@ -1951,7 +1951,7 @@ BOOL OpenFileForCompress(
     //  Turn OFF the READONLY attribute.
     //
     fi.dwFileAttributes &= ~FILE_ATTRIBUTE_READONLY;
-    if (!SetFileAttributes(szFile, fi.dwFileAttributes))
+    if (!WfWowSetFileAttributes(szFile, fi.dwFileAttributes))
     {
         CloseHandle(hAttr);
         return (FALSE);
@@ -1960,13 +1960,13 @@ BOOL OpenFileForCompress(
     //
     //  Try again to open the file - READ_DATA | WRITE_DATA.
     //
-    *phFile = CreateFile( szFile,
-                          FILE_READ_DATA | FILE_WRITE_DATA,
-                          FILE_SHARE_READ | FILE_SHARE_WRITE,
-                          NULL,
-                          OPEN_EXISTING,
-                          FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_SEQUENTIAL_SCAN,
-                          NULL );
+    *phFile = WfWowCreateFile( szFile,
+                               FILE_READ_DATA | FILE_WRITE_DATA,
+                               FILE_SHARE_READ | FILE_SHARE_WRITE,
+                               NULL,
+                               OPEN_EXISTING,
+                               FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_SEQUENTIAL_SCAN,
+                               NULL );
 
     //
     //  Close the file handle opened for READ_ATTRIBUTE | WRITE_ATTRIBUTE.
@@ -1986,7 +1986,7 @@ BOOL OpenFileForCompress(
     //  Turn the READONLY attribute back ON.
     //
     fi.dwFileAttributes |= FILE_ATTRIBUTE_READONLY;
-    if (!SetFileAttributes(szFile, fi.dwFileAttributes))
+    if (!WfWowSetFileAttributes(szFile, fi.dwFileAttributes))
     {
         CloseHandle(*phFile);
         *phFile = INVALID_HANDLE_VALUE;

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -987,6 +987,8 @@ InitFileManager(
 
    SetThreadPriority(hThread, THREAD_PRIORITY_ABOVE_NORMAL);
 
+   WfWowInitialize();
+
    InitializeCriticalSection(&CriticalSectionPath);
 
    // ProfStart();
@@ -1004,7 +1006,7 @@ InitFileManager(
    dwRetval = GetEnvironmentVariable(TEXT("APPDATA"), szBuffer, MAXPATHLEN);
    if (dwRetval > 0 && dwRetval <= (DWORD)(MAXPATHLEN - lstrlen(szRoamINIPath) - 1 - lstrlen(szBaseINIFile) - 1)) {
 	   wsprintf(szTheINIFile, TEXT("%s%s"), szBuffer, szRoamINIPath);
-	   if (CreateDirectory(szTheINIFile, NULL) || GetLastError() == ERROR_ALREADY_EXISTS) {
+	   if (WfWowCreateDirectory(szTheINIFile, NULL) || GetLastError() == ERROR_ALREADY_EXISTS) {
 		   wsprintf(szTheINIFile, TEXT("%s%s\\%s"), szBuffer, szRoamINIPath, szBaseINIFile);
 	   }
 	   else {

--- a/src/wfprint.c
+++ b/src/wfprint.c
@@ -40,7 +40,7 @@ PrintFile(HWND hwnd, LPTSTR szFile)
    // open the object
    //
    SetErrorMode(0);
-   ret = (DWORD_PTR)ShellExecute(hwnd, L"print", szFile, szNULL, szDir, SW_SHOWNORMAL);
+   ret = (DWORD_PTR)WfWowShellExecute(hwnd, L"print", szFile, szNULL, szDir, SW_SHOWNORMAL);
    SetErrorMode(1);
 
    switch (ret) {

--- a/src/wfutil.c
+++ b/src/wfutil.c
@@ -242,7 +242,7 @@ BOOL  GetDriveDirectory(INT iDrive, LPTSTR pszDir)
         drvstr[1] = ('\0');
     }
 
-	if (GetFileAttributes(drvstr) == INVALID_FILE_ATTRIBUTES)
+	if (WfWowGetFileAttributes(drvstr) == INVALID_FILE_ATTRIBUTES)
 		return FALSE;
 
 //	if (!CheckDirExists(drvstr))
@@ -1447,7 +1447,7 @@ ExecProgram(LPTSTR lpPath, LPTSTR lpParms, LPTSTR lpDir, BOOL bLoadIt, BOOL bRun
      lpszTitle++;
 
   SetErrorMode(0);
-  ret = (DWORD_PTR) ShellExecute(hwndFrame, bRunAs ? L"runas" : NULL, lpPath, lpParms, lpDir, bLoadIt ? SW_SHOWMINNOACTIVE : SW_SHOWNORMAL);
+  ret = (DWORD_PTR) WfWowShellExecute(hwndFrame, bRunAs ? L"runas" : NULL, lpPath, lpParms, lpDir, bLoadIt ? SW_SHOWMINNOACTIVE : SW_SHOWNORMAL);
 
   SetErrorMode(1);
 

--- a/src/wfwow.c
+++ b/src/wfwow.c
@@ -1,0 +1,338 @@
+/********************************************************************
+
+   wfwow.c
+
+   Windows File Manager Wow64 wrapper routines
+   
+   Since the file manager needs to display files as they exist on
+   disk, Win32 functions querying or manipulating files need to
+   suppress Wow64 redirection.  Any Win32 API that consumes a file
+   path should be wrapped within this file.
+
+   Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License.
+
+********************************************************************/
+
+#include "winfile.h"
+#include "lfn.h"
+
+#define KERNEL32_DLL TEXT("kernel32.dll")
+BOOL (CALLBACK *lpfnWow64DisableWow64FsRedirection)(PVOID *);
+BOOL (CALLBACK *lpfnWow64RevertWow64FsRedirection)(PVOID);
+
+#define KERNEL32_Wow64DisableWow64FsRedirection "Wow64DisableWow64FsRedirection"
+#define KERNEL32_Wow64RevertWow64FsRedirection  "Wow64RevertWow64FsRedirection"
+
+#define Wow64DisableWow64FsRedirection   (*lpfnWow64DisableWow64FsRedirection)
+#define Wow64RevertWow64FsRedirection    (*lpfnWow64RevertWow64FsRedirection)
+
+
+VOID
+WfWowInitialize()
+{
+   HANDLE hKernel32;
+   hKernel32 = GetModuleHandle(KERNEL32_DLL);
+
+   lpfnWow64DisableWow64FsRedirection = (PVOID)GetProcAddress(hKernel32, KERNEL32_Wow64DisableWow64FsRedirection);
+   lpfnWow64RevertWow64FsRedirection = (PVOID)GetProcAddress(hKernel32, KERNEL32_Wow64RevertWow64FsRedirection);
+}
+
+typedef struct _WF_WOW_STATE {
+    PVOID OldValue;
+    BOOLEAN RevertRequired;
+} WF_WOW_STATE, *PWF_WOW_STATE;
+
+VOID
+WfWowDisableRedirection(PWF_WOW_STATE State)
+{
+    State->RevertRequired = FALSE;
+    if (lpfnWow64DisableWow64FsRedirection != NULL) {
+        if (Wow64DisableWow64FsRedirection(&State->OldValue)) {
+            State->RevertRequired = TRUE;
+        }
+    }
+}
+
+VOID
+WfWowRevertRedirection(PWF_WOW_STATE State)
+{
+    if (State->RevertRequired &&
+        lpfnWow64RevertWow64FsRedirection != NULL) {
+
+        Wow64RevertWow64FsRedirection(State->OldValue);
+    }
+}
+
+BOOL
+WfWowCopyFile(
+    LPCWSTR lpExistingFileName,
+    LPCWSTR lpNewFileName,
+    BOOL bFailIfExists
+    )
+{
+    WF_WOW_STATE WowState;
+    BOOL Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = CopyFile(lpExistingFileName, lpNewFileName, bFailIfExists);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+BOOL
+WfWowCopyFileEx(
+    LPCWSTR lpExistingFileName,
+    LPCWSTR lpNewFileName,
+    LPPROGRESS_ROUTINE lpProgressRoutine,
+    LPVOID lpData,
+    LPBOOL pbCancel,
+    DWORD dwCopyFlags
+    )
+{
+    WF_WOW_STATE WowState;
+    BOOL Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = CopyFileEx(lpExistingFileName, lpNewFileName, lpProgressRoutine, lpData, pbCancel, dwCopyFlags);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+BOOL
+WfWowCreateDirectory(
+    LPCWSTR lpPathName,
+    LPSECURITY_ATTRIBUTES lpSecurityAttributes
+    )
+{
+    WF_WOW_STATE WowState;
+    BOOL Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = CreateDirectory(lpPathName, lpSecurityAttributes);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+BOOL
+WfWowCreateDirectoryEx(
+    LPCWSTR lpTemplateDirectory,
+    LPCWSTR lpNewDirectory,
+    LPSECURITY_ATTRIBUTES lpSecurityAttributes
+    )
+{
+    WF_WOW_STATE WowState;
+    BOOL Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = CreateDirectoryEx(lpTemplateDirectory, lpNewDirectory, lpSecurityAttributes);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+HANDLE
+WfWowCreateFile(
+    LPCWSTR lpFileName,
+    DWORD dwDesiredAccess,
+    DWORD dwShareMode,
+    LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+    DWORD dwCreationDisposition,
+    DWORD dwFlagsAndAttributes,
+    HANDLE hTemplateFile
+    )
+{
+    WF_WOW_STATE WowState;
+    HANDLE Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = CreateFile(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+BOOLEAN
+WfWowCreateSymbolicLink (
+    LPCWSTR lpSymlinkFileName,
+    LPCWSTR lpTargetFileName,
+    DWORD dwFlags
+    )
+{
+    WF_WOW_STATE WowState;
+    BOOLEAN Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = CreateSymbolicLink(lpSymlinkFileName, lpTargetFileName, dwFlags);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+BOOL
+WfWowDeleteFile(
+    LPCWSTR lpFileName
+    )
+{
+    WF_WOW_STATE WowState;
+    BOOL Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = DeleteFile(lpFileName);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+HANDLE
+WfWowFindFirstFile(
+    LPCWSTR lpFileName,
+    LPWIN32_FIND_DATAW lpFindFileData
+    )
+{
+    WF_WOW_STATE WowState;
+    HANDLE Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = FindFirstFile(lpFileName, lpFindFileData);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+HANDLE
+WfWowFindFirstFileEx(
+    LPCWSTR lpFileName,
+    FINDEX_INFO_LEVELS fInfoLevelId,
+    LPVOID lpFindFileData,
+    FINDEX_SEARCH_OPS fSearchOp,
+    LPVOID lpSearchFilter,
+    DWORD dwAdditionalFlags
+    )
+{
+    WF_WOW_STATE WowState;
+    HANDLE Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = FindFirstFileEx(lpFileName, fInfoLevelId, lpFindFileData, fSearchOp, lpSearchFilter, dwAdditionalFlags);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+BOOL
+WfWowFindNextFile(
+    HANDLE hFindFile,
+    LPWIN32_FIND_DATAW lpFindFileData
+    )
+{
+    WF_WOW_STATE WowState;
+    BOOL Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = FindNextFile(hFindFile, lpFindFileData);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+DWORD
+WfWowGetCompressedFileSize(
+    LPCWSTR lpFileName,
+    LPDWORD lpFileSizeHigh
+    )
+{
+    WF_WOW_STATE WowState;
+    DWORD Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = GetCompressedFileSize(lpFileName, lpFileSizeHigh);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+DWORD
+WfWowGetFileAttributes(
+    LPCWSTR lpFileName
+    )
+{
+    WF_WOW_STATE WowState;
+    DWORD Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = GetFileAttributes(lpFileName);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+BOOL
+WfWowMoveFile(
+    LPCWSTR lpExistingFileName,
+    LPCWSTR lpNewFileName
+    )
+{
+    WF_WOW_STATE WowState;
+    BOOL Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = MoveFile(lpExistingFileName, lpNewFileName);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+BOOL
+WfWowRemoveDirectory(
+    LPCWSTR lpPathName
+    )
+{
+    WF_WOW_STATE WowState;
+    BOOL Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = RemoveDirectory(lpPathName);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+BOOL
+WfWowSetFileAttributes(
+    LPCWSTR lpFileName,
+    DWORD dwFileAttributes
+    )
+{
+    WF_WOW_STATE WowState;
+    BOOL Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = SetFileAttributes(lpFileName, dwFileAttributes);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+HINSTANCE
+WfWowShellExecute(
+    HWND hwnd,
+    LPCWSTR lpOperation,
+    LPCWSTR lpFile,
+    LPCWSTR lpParameters,
+    LPCWSTR lpDirectory,
+    INT nShowCmd
+    )
+{
+    WF_WOW_STATE WowState;
+    HINSTANCE Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = ShellExecute(hwnd, lpOperation, lpFile, lpParameters, lpDirectory, nShowCmd);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+BOOL
+WfWowShellExecuteEx(
+    SHELLEXECUTEINFOW *pExecInfo
+    )
+{
+    WF_WOW_STATE WowState;
+    BOOL Result;
+
+    WfWowDisableRedirection(&WowState);
+    Result = ShellExecuteEx(pExecInfo);
+    WfWowRevertRedirection(&WowState);
+    return Result;
+}
+
+

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -657,6 +657,26 @@ VOID  InvalidateAllNetTypes(VOID);
 VOID  GetTreeUNCName(HWND hwndTree, LPTSTR szBuf, INT nBuf);
 BOOL  RectTreeItem(HWND hwndLB, register INT iItem, BOOL bFocusOn);
 
+VOID    WfWowInitialize();
+
+BOOL    WfWowCopyFile(LPCWSTR lpExistingFileName, LPCWSTR lpNewFileName, BOOL bFailIfExists);
+BOOL    WfWowCopyFileEx(LPCWSTR lpExistingFileName, LPCWSTR lpNewFileName, LPPROGRESS_ROUTINE lpProgressRoutine, LPVOID lpData, LPBOOL pbCancel, DWORD dwCopyFlags);
+BOOL    WfWowCreateDirectory(LPCWSTR lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes);
+BOOL    WfWowCreateDirectoryEx(LPCWSTR lpTemplateDirectory, LPCWSTR lpNewDirectory, LPSECURITY_ATTRIBUTES lpSecurityAttributes);
+HANDLE  WfWowCreateFile(LPCWSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile);
+BOOLEAN WfWowCreateSymbolicLink(LPCWSTR lpSymlinkFileName, LPCWSTR lpTargetFileName, DWORD dwFlags);
+BOOL    WfWowDeleteFile(LPCWSTR lpFileName);
+HANDLE  WfWowFindFirstFile(LPCWSTR lpFileName, LPWIN32_FIND_DATAW lpFindFileData);
+HANDLE  WfWowFindFirstFileEx(LPCWSTR lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, LPVOID lpFindFileData, FINDEX_SEARCH_OPS fSearchOp, LPVOID lpSearchFilter, DWORD dwAdditionalFlags);
+BOOL    WfWowFindNextFile(HANDLE hFindFile, LPWIN32_FIND_DATAW lpFindFileData);
+DWORD   WfWowGetCompressedFileSize(LPCWSTR lpFileName, LPDWORD lpFileSizeHigh);
+DWORD   WfWowGetFileAttributes(LPCWSTR lpFileName);
+BOOL    WfWowMoveFile(LPCWSTR lpExistingFileName, LPCWSTR lpNewFileName);
+BOOL    WfWowRemoveDirectory(LPCWSTR lpPathName);
+BOOL    WfWowSetFileAttributes(LPCWSTR lpFileName, DWORD dwFileAttributes);
+HINSTANCE WfWowShellExecute(HWND hwnd, LPCWSTR lpOperation, LPCWSTR lpFile, LPCWSTR lpParameters, LPCWSTR lpDirectory, INT nShowCmd);
+BOOL    WfWowShellExecuteEx(SHELLEXECUTEINFOW *pExecInfo);
+
 
 //--------------------------------------------------------------------------
 //


### PR DESCRIPTION
This wraps file system API calls with wrappers that disable Wow64 redirection.  Prior to this change, enumeration disabled redirection, so the UI is populated with "real" file system contents, but attempting to query or manipulate those contents was still subject to redirection, creating inconsistent and unexpected results.

To test this I created a directory in \Windows\System32\test, compiled as 32 bit, and attempted to work through as many operations as I could think of.

Note there's an alternative approach of using the preprocessor to automatically remap FS APIs to use wrappers.  That's not my preferred approach, but it is an option.  After this change it's basically a bug to call the FS API without using these wrappers.