### PR TITLE
Update VerifyResources to handle custom control creation data

### DIFF
--- a/tools/VerifyResources/VerifyResources.cpp
+++ b/tools/VerifyResources/VerifyResources.cpp
@@ -262,7 +262,7 @@ VOID DecodeDlgItem(WORD **ppwT, BOOL bExtended, DLGITEMDECODE *pdecitem)
     if (pdecitem->cbCreate == 0)
         pwT++;
     else
-        pwT = (WORD *)((char *)pwT + pdecitem->cbCreate);
+        pwT = (WORD *)((char *)pwT + pdecitem->cbCreate + sizeof(WORD));
 
     // align on DWORD boundary
     pwT = (WORD *)RAWINPUT_ALIGN((INT_PTR)pwT);
@@ -439,7 +439,7 @@ VOID VerifyLangDialogs(PROCRES *pprocres)
 
             if (pdecitem->pitem->id != id)
             {
-                printf("Error: dialog %ls for language %ls does not have the required item %d\n", pdecdlgEng->lpszTitle, szLocale, id);
+                printf("Error: dialog %ls item #%d for language %ls has unexpected ID, have %d expect %d\n", pdecdlgEng->lpszTitle, i, szLocale, id, pdecitem->pitem->id);
                 break;
             }
 


### PR DESCRIPTION
VerifyResources is attempting to navigate controls within an in-memory dialog template, and needs to know the number of bytes within each control.  Controls can include optional additional creation data.  When skipping this data, it's important to skip not just the data but also the field indicating the number of bytes of creation data; this is skipped when no data is present, but was not skipped when additional data is present.  This results in VerifyResources being in the wrong offset and interpreting localized strings as control data, causing it to complain about resource mismatches continually.