### PR TITLE
Very long path

### DIFF
--- a/src/Winfile.vcxproj
+++ b/src/Winfile.vcxproj
@@ -158,6 +158,7 @@
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+      <AdditionalOptions>/stack:15000000 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -213,6 +214,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX86</TargetMachine>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+      <AdditionalOptions>/stack:15000000 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -268,6 +270,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX64</TargetMachine>
+      <AdditionalOptions>/stack:15000000 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -296,6 +299,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX64</TargetMachine>
+      <AdditionalOptions>/stack:15000000 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/wfassoc.c
+++ b/src/wfassoc.c
@@ -17,10 +17,10 @@
 #define DDETYPECOMBOBOXSIZ 20
 #define DDETYPEMAX  (sizeof(aDDEType) / sizeof(aDDEType[0]))
 
-#define STRINGSIZ  MAX_PATH   // at least >= {DESCSIZ, IDENTSIZ}
-#define DESCSIZ    MAX_PATH
-#define COMMANDSIZ MAX_PATH
-#define DDESIZ     MAX_PATH
+#define STRINGSIZ  MAXPATHLEN   // at least >= {DESCSIZ, IDENTSIZ}
+#define DESCSIZ    MAXPATHLEN
+#define COMMANDSIZ MAXPATHLEN
+#define DDESIZ     MAXPATHLEN
 
 #define FILETYPEBLOCK MAX_PATH
 
@@ -306,7 +306,7 @@ UpdateSelectionExt(HWND hDlg, BOOL bForce)
    PTCHAR p;
    PFILETYPE pFileType;
 
-   TCHAR szTemp[MAX_PATH];
+   TCHAR szTemp[MAXPATHLEN];
 
    //
    // bForce is used when we base the ext on GETCURSEL rather than
@@ -926,7 +926,7 @@ Cancel:
             OPENFILENAME ofn;
             DWORD dwSave = dwContext;
 
-            TCHAR szFile[MAX_PATH + 2];
+            TCHAR szFile[MAXPATHLEN + 2];
 
             LPTSTR p;
 
@@ -1509,8 +1509,8 @@ Reload:
          DWORD dwSave = dwContext;
          LPTSTR p;
 
-         TCHAR szFile[MAX_PATH + 2];
-         TCHAR szTemp2[MAX_PATH];
+         TCHAR szFile[MAXPATHLEN + 2];
+         TCHAR szTemp2[MAXPATHLEN];
 
          dwContext = IDH_ASSOC_BROWSE;
 
@@ -2623,7 +2623,7 @@ Error:
 DWORD
 DDERead(PASSOCIATEFILEDLGINFO pAssociateFileDlgInfo, INT i)
 {
-   TCHAR szKey[MAX_PATH];
+   TCHAR szKey[MAXPATHLEN];
    INT iPoint;
    LONG lSize;
    DWORD dwError;
@@ -2756,7 +2756,7 @@ DDERead(PASSOCIATEFILEDLGINFO pAssociateFileDlgInfo, INT i)
 DWORD
 DDEWrite(PASSOCIATEFILEDLGINFO pAssociateFileDlgInfo, INT i)
 {
-   TCHAR szKey[MAX_PATH];
+   TCHAR szKey[MAXPATHLEN];
    INT iPoint;
    DWORD dwSize;
    DWORD dwError;
@@ -3233,9 +3233,9 @@ AssociateFileDlgExtAdd(HWND hDlg,
          // That it belongs to some other pFileType, we must ask
          // the user if we really can do this.
 
-         TCHAR szText[MAX_PATH];
-         TCHAR szTitle[MAX_PATH];
-         TCHAR szTemp[MAX_PATH];
+         TCHAR szText[MAXPATHLEN];
+         TCHAR szTitle[MAXPATHLEN];
+         TCHAR szTemp[MAXPATHLEN];
 
          //
          // If it's already associated to something that's
@@ -3535,7 +3535,7 @@ RegNodeDelete(HKEY hk, LPTSTR lpszKey)
 {
     HKEY hkNode;
     DWORD dwError;
-    TCHAR szKey[MAX_PATH];
+    TCHAR szKey[MAXPATHLEN];
    
    
     dwError = RegOpenKey(hk, lpszKey, &hkNode);

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -692,8 +692,8 @@ OpenOrEditSelection(HWND hwndActive, BOOL fEdit)
       //
       if (fEdit)
       {
-          TCHAR szEditPath[MAX_PATH];
-          TCHAR szNotepad[MAX_PATH];
+          TCHAR szEditPath[MAXPATHLEN];
+          TCHAR szNotepad[MAXPATHLEN];
 
           // NOTE: assume system directory and "\\notepad.exe" never exceed MAXPATHLEN
           if (GetSystemDirectory(szNotepad, MAXPATHLEN) != 0)
@@ -701,7 +701,7 @@ OpenOrEditSelection(HWND hwndActive, BOOL fEdit)
           else
               lstrcpy(szNotepad, TEXT("notepad.exe"));
 
-          GetPrivateProfileString(szSettings, szEditorPath, szNotepad, szEditPath, MAX_PATH, szTheINIFile);
+          GetPrivateProfileString(szSettings, szEditorPath, szNotepad, szEditPath, MAXPATHLEN, szTheINIFile);
 
           CheckEsc(szPath);     // add quotes if necessary; reserved space for them above
 

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -601,7 +601,7 @@ OpenOrEditSelection(HWND hwndActive, BOOL fEdit)
    DWORD ret;
    HCURSOR hCursor;
 
-   WCHAR szPath[MAXPATHLEN+2];  // +2 for quotes if needed
+   WCHAR szPath[MAXPATHLEN * 2 + 2];  // +2 for quotes if needed, * 2 because CreateDirWindow() assumes a filename can be the same length as MAXPATHLEN
 
    HWND hwndTree, hwndDir, hwndFocus;
 

--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -2433,8 +2433,8 @@ TRY_COPY_AGAIN:
          if (bSameFile && pCopyInfo->dwFunc == FUNC_COPY && (oper != OPER_RMDIR)) {
 
             // Source and destination are exactly the same
-            WCHAR szDestAlt[MAX_PATH + 2] = { 0 };
-            WCHAR szExtension[MAX_PATH + 2] = { 0 };
+            WCHAR szDestAlt[MAXPATHLEN + 2] = { 0 };
+            WCHAR szExtension[MAXPATHLEN + 2] = { 0 };
             LPTSTR pExt;
 
             lstrcpy(szDestAlt, szDest);

--- a/src/wfdlgs.c
+++ b/src/wfdlgs.c
@@ -708,11 +708,11 @@ DoHelp:
 INT_PTR CALLBACK PrefDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
     /* Editor prefrence variables*/
-    TCHAR szTempEditPath[MAX_PATH];
-    TCHAR szPath[MAX_PATH];
-    TCHAR szFilter[MAX_PATH] = { 0 };
+    TCHAR szTempEditPath[MAXPATHLEN];
+    TCHAR szPath[MAXPATHLEN];
+    TCHAR szFilter[MAXPATHLEN] = { 0 };
 
-    LoadString(hAppInstance, IDS_EDITFILTER, szFilter, MAX_PATH);
+    LoadString(hAppInstance, IDS_EDITFILTER, szFilter, MAXPATHLEN);
 
     OPENFILENAME ofn;
 
@@ -737,7 +737,7 @@ INT_PTR CALLBACK PrefDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
         case WM_INITDIALOG:
             InitLangList(hLangComboBox);
 
-            GetPrivateProfileString(szSettings, szEditorPath, NULL, szTempEditPath, MAX_PATH, szTheINIFile);
+            GetPrivateProfileString(szSettings, szEditorPath, NULL, szTempEditPath, MAXPATHLEN, szTheINIFile);
             SetDlgItemText(hDlg, IDD_EDITOR, szTempEditPath);
 
             CheckDlgButton(hDlg, IDC_VSTYLE, bDisableVisualStyles);
@@ -757,7 +757,7 @@ INT_PTR CALLBACK PrefDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 
                     if ((*lpfnGetOpenFileNameW)(&ofn))
                     {
-                        wcscpy_s(szPath, MAX_PATH, ofn.lpstrFile);
+                        wcscpy_s(szPath, MAXPATHLEN, ofn.lpstrFile);
                         SetDlgItemText(hDlg, IDD_EDITOR, szPath);
                     }
                     break;
@@ -765,7 +765,7 @@ INT_PTR CALLBACK PrefDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
                 case IDOK:
                     SaveLang(hLangComboBox);
 
-                    GetDlgItemText(hDlg, IDD_EDITOR, szTempEditPath, MAX_PATH);
+                    GetDlgItemText(hDlg, IDD_EDITOR, szTempEditPath, MAXPATHLEN);
                     WritePrivateProfileString(szSettings, szEditorPath, szTempEditPath, szTheINIFile);
 
                     bDisableVisualStyles = IsDlgButtonChecked(hDlg, IDC_VSTYLE);

--- a/src/wfdlgs3.c
+++ b/src/wfdlgs3.c
@@ -1830,14 +1830,14 @@ DestroyCancelWindow()
 BOOL GetProductVersion(WORD * pwMajor, WORD * pwMinor, WORD * pwBuild, WORD * pwRevision)
 {
     BOOL               success = FALSE;
-    TCHAR              szCurrentModulePath[MAX_PATH];
+    TCHAR              szCurrentModulePath[MAXPATHLEN];
     DWORD              cchPath;
     DWORD              cbVerInfo;
     LPVOID             pFileVerInfo;
     UINT               uLen;
     VS_FIXEDFILEINFO * pFixedFileInfo;
 
-    cchPath = GetModuleFileName(NULL, szCurrentModulePath, MAX_PATH);
+    cchPath = GetModuleFileName(NULL, szCurrentModulePath, MAXPATHLEN);
 
     if (cchPath && GetLastError() != ERROR_INSUFFICIENT_BUFFER)
     {

--- a/src/wfdrop.c
+++ b/src/wfdrop.c
@@ -248,7 +248,7 @@ LPWSTR QuotedContentList(IDataObject *pDataObject)
             STGMEDIUM sm_content = {0,0,0};
 			unsigned int file_index;
             size_t cchTempPath, cchFiles;
-            WCHAR szTempPath[MAX_PATH+1];
+            WCHAR szTempPath[MAXPATHLEN +1];
 
             hr = pDataObject->lpVtbl->GetData(pDataObject, &descriptor_format, &sm_desc);
 			if (hr != S_OK)
@@ -256,7 +256,7 @@ LPWSTR QuotedContentList(IDataObject *pDataObject)
 
             file_group_descriptor = (FILEGROUPDESCRIPTOR *) GlobalLock(sm_desc.hGlobal);
 
-			GetTempPath(MAX_PATH, szTempPath);
+			GetTempPath(MAXPATHLEN, szTempPath);
 			cchTempPath = wcslen(szTempPath);
 
 			// calc total size of file names

--- a/src/wfloc.c
+++ b/src/wfloc.c
@@ -29,7 +29,7 @@ VOID InitLangList(HWND hCBox)
     // Propogate the list
     for (UINT i = 0; i <= (COUNTOF(szLCIDs) - 1); i++)
     {
-        TCHAR szLangName[MAX_PATH] = { 0 };
+        TCHAR szLangName[MAXPATHLEN] = { 0 };
         LCID lcidTemp = LocaleNameToLCID(szLCIDs[i], 0);
 
         // TODO: need to test this on pre-Vista and on/after Win XP 64

--- a/src/winfile.c
+++ b/src/winfile.c
@@ -295,7 +295,7 @@ InitPopupMenus(UINT uMenus, HMENU hMenu, HWND hwndActive)
          //
 
          // get a buffer big enough for a quoted path
-         TCHAR szTemp[MAX_PATH + 2 * sizeof(TCHAR)];
+         TCHAR szTemp[MAXPATHLEN + 2 * sizeof(TCHAR)];
 
          lstrcpy( szTemp, pSel);
 

--- a/src/winfile.exe.manifest
+++ b/src/winfile.exe.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
 	<dependency>
 		<dependentAssembly>
 			<assemblyIdentity
@@ -27,5 +27,9 @@
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
-  
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <ws2:longPathAware>true</ws2:longPathAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
 </assembly>

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -92,8 +92,8 @@ INT atoiW(LPWSTR sz);
 #define MAXDOSFILENAMELEN   (12+1)            // includes the NULL
 #define MAXDOSPATHLEN       (68+MAXDOSFILENAMELEN)  // includes the NULL
 
-#define MAXLFNFILENAMELEN   260
-#define MAXLFNPATHLEN       260
+#define MAXLFNFILENAMELEN   1024
+#define MAXLFNPATHLEN       1024
 
 #define MAXFILENAMELEN      MAXLFNFILENAMELEN
 #define MAXPATHLEN          MAXLFNPATHLEN


### PR DESCRIPTION
### Problems
Ever since Winfile supports path lengths up to 256 characters. In certain situations it is useful to have more. Windows supports 32767, but this PR aims less and increases up to 1024
It also addresses the request from #50

### Changes
* MAX_PATH occurrences were replaced with MAXPATHLEN so that there is one common definition for the length
* Added the long longPathAware manifest
* Added verylongpath.reg file which lifts the 256 character limitation for Windows 10 system > 1607. Can be [found here] (https://github.com/microsoft/winfile/files/9175242/TestVeryLongPath.zip)

* Increased the stacksize so that filling the Goto-Cache survives 512 levels of recursion
* Fixed a bug which was there anyhow via  [44991cb]

### How to test
Take [TestDeepPath.bat](https://github.com/microsoft/winfile/files/9175242/TestVeryLongPath.zip) and run it. A path with about 750 chars is created
Now play around, and navigate through it. Do all you think should work

### Status
Basically this PR works quite well, but it is very experimental, because a change like this 
* is hard to test, because all tests are manual
* the achieved test coverage is unknown.
So it is a draft PR, just for all who want to compile their own Winfile and maybe it works
