### PR TITLE
Control tree view scroll behavior on expand via winfile.ini[Settings]…

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ selecting one changes to that directory.  Default = c:\. Confgigure via Winfile.
 normal date sorting is newest on top
 16. CTRL + ENTER executes associated files as administrator
 19. The delimiters for splitting words for the GotoCache can be configured via Winfile.ini[Settings]GotoCachePunctuation. The default is - _.
+20. The scroll behavior of the treeview on expand can be configured via Winfile.ini[Settings]ScrollOnExpand. The default is to scroll.
 
 You can read the code for more details.
 

--- a/src/treectl.c
+++ b/src/treectl.c
@@ -2028,7 +2028,9 @@ ExpandLevel(HWND hWnd, WPARAM wParam, INT nIndex, LPTSTR szPath)
 
     iNewTopIndex = min((INT)iCurrentIndex, iTopIndex + iNumExpanded - iExpandInView + 1);
 
-    SendMessage(hwndLB, LB_SETTOPINDEX, (WPARAM)iNewTopIndex, 0L);
+    // Control tree view scroll behavior on expand via winfile.ini[Settings]ScrollOnExpand. Default == TRUE
+    if (TRUE == bScrollOnExpand)
+      SendMessage(hwndLB, LB_SETTOPINDEX, (WPARAM)iNewTopIndex, 0L);
   }
 
   SendMessage(hwndLB, WM_SETREDRAW, TRUE, 0L);

--- a/src/wfdlgs.c
+++ b/src/wfdlgs.c
@@ -53,6 +53,8 @@ SaveWindows(HWND hwndMain)
 
    WritePrivateProfileString(szSettings, szWindow, buf2, szTheINIFile);
 
+   WritePrivateProfileBool(szScrollOnExpand, bScrollOnExpand);
+
    // write out dir window strings in reverse order
    // so that when we read them back in we get the same Z order
 

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -234,6 +234,7 @@ GetSettings()
    bConfirmReadOnly= GetPrivateProfileInt(szSettings, szConfirmReadOnly, bConfirmReadOnly, szTheINIFile);
    uChangeNotifyTime= GetPrivateProfileInt(szSettings, szChangeNotifyTime, uChangeNotifyTime, szTheINIFile);
    bSaveSettings   = GetPrivateProfileInt(szSettings, szSaveSettings,  bSaveSettings, szTheINIFile);
+   bScrollOnExpand = GetPrivateProfileInt(szSettings, szScrollOnExpand, bScrollOnExpand, szTheINIFile);
    weight = GetPrivateProfileInt(szSettings, szFaceWeight, 400, szTheINIFile);
 
    GetPrivateProfileString(szSettings,

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -1161,7 +1161,8 @@ Extern BOOL bConfirmMouse    EQ( TRUE );
 Extern BOOL bConfirmFormat   EQ( TRUE );
 Extern BOOL bConfirmReadOnly EQ( TRUE );
 
-Extern BOOL bSaveSettings   EQ( TRUE );
+Extern BOOL bSaveSettings    EQ( TRUE );
+Extern BOOL bScrollOnExpand  EQ( TRUE );
 
 Extern BOOL bConnectable       EQ( FALSE );
 Extern BOOL fShowSourceBitmaps EQ( TRUE );
@@ -1192,6 +1193,7 @@ Extern TCHAR        szMinOnRun[]            EQ( TEXT("MinOnRun") );
 Extern TCHAR        szIndexOnLaunch[]       EQ( TEXT("IndexOnLaunch") );
 Extern TCHAR        szStatusBar[]           EQ( TEXT("StatusBar") );
 Extern TCHAR        szSaveSettings[]        EQ( TEXT("Save Settings") );
+Extern TCHAR        szScrollOnExpand[]      EQ( TEXT("ScrollOnExpand"));
 
 Extern TCHAR        szConfirmDelete[]       EQ( TEXT("ConfirmDelete") );
 Extern TCHAR        szConfirmSubDel[]       EQ( TEXT("ConfirmSubDel") );


### PR DESCRIPTION
Control tree view scroll behavior on expand via winfile.ini[Settings]ScrollOnExpand. Default == TRUE
Solves #338