### PR TITLE
Save CachedPath and GotoCachePunctuation

### DIFF
--- a/src/wfdlgs.c
+++ b/src/wfdlgs.c
@@ -119,6 +119,10 @@ DO_AGAIN:
 
       goto DO_AGAIN;
    }
+
+   // Save CachedPath and GotoCachePunctuation
+   WritePrivateProfileString(szSettings, szCachedPath, szCachedPathIni, szTheINIFile);
+   WritePrivateProfileString(szSettings, szGotoCachePunctuation, szPunctuation, szTheINIFile);
 }
 
 

--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -715,8 +715,11 @@ BuildDirectoryTreeBagOValues(PVOID pv)
 	GetPrivateProfileString(szSettings, szGotoCachePunctuation, TEXT("- _."), szPunctuation, MAXPATHLEN, szTheINIFile);
 
 	// Read pathes, which shall be cached from winfile.ini
+	GetPrivateProfileString(szSettings, szCachedPath, TEXT("c:\\"), szCachedPathIni, MAXPATHLEN, szTheINIFile);
+
+	// Create a local copy, because once we save it to winfile.ini on exit we need the original value
 	TCHAR szCached[MAXPATHLEN];
-	GetPrivateProfileString(szSettings, szCachedPath, TEXT("c:\\"), szCached, MAXPATHLEN, szTheINIFile);
+	lstrcpy(szCached, szCachedPathIni);
 
 	// Iterate through ; seperated list of to be cached pathes
 	BOOL     buildBag{ FALSE };

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -1185,6 +1185,7 @@ Extern TCHAR        szUILanguage[]          EQ( TEXT("UILanguage") );
 Extern TCHAR        szEditorPath[]          EQ( TEXT("EditorPath"));
 Extern TCHAR        szMirrorContent[]       EQ( TEXT("MirrorContent") );
 Extern TCHAR        szCachedPath[]          EQ( TEXT("CachedPath"));
+Extern TCHAR        szCachedPathIni[MAXPATHLEN];
 Extern TCHAR        szGotoCachePunctuation[] EQ(TEXT("GotoCachePunctuation"));
 Extern TCHAR        szPunctuation[MAXPATHLEN];
 


### PR DESCRIPTION
Save CachedPath and GotoCachePunctuation on exit, because if it lacks from the .ini file, it has to be created somehow.

I missed this once I did those extensions to winfile.ini in #293 and #329
It is needed because otherwise the *initial* .ini file entries must to be created manually, which is cumbersome and error prone.

With this change the .ini entries are there with a default value, and the user simply can change just the value.