### PR TITLE
FS_GETFILESPEC caused buffer overflows on too small buffers in 3 places:

### DIFF
--- a/src/treectl.c
+++ b/src/treectl.c
@@ -2566,7 +2566,7 @@ TreeControlWndProc(
       {
          HWND hwndDir;
          INT CurSel;
-         WCHAR szFileSpec[MAXPATHLEN];
+         UINT uStrLen;
 
          //
          // CurSel is returned from SendMessage
@@ -2579,9 +2579,8 @@ TreeControlWndProc(
 
          AddBackslash(szPath);
 
-         SendMessage(hwndParent, FS_GETFILESPEC, COUNTOF(szFileSpec),
-                     (LPARAM)szFileSpec);
-         lstrcat(szPath, szFileSpec);
+         uStrLen = lstrlen(szPath);
+         SendMessage(hwndParent, FS_GETFILESPEC, COUNTOF(szPath) - uStrLen, (LPARAM)(szPath + uStrLen));
 
          if (hwndDir = HasDirWindow(hwndParent)) {
 

--- a/src/treectl.c
+++ b/src/treectl.c
@@ -2566,7 +2566,7 @@ TreeControlWndProc(
       {
          HWND hwndDir;
          INT CurSel;
-         UINT uStrLen;
+         WCHAR szFileSpec[MAXPATHLEN];
 
          //
          // CurSel is returned from SendMessage
@@ -2579,9 +2579,9 @@ TreeControlWndProc(
 
          AddBackslash(szPath);
 
-         uStrLen = lstrlen(szPath);
-         SendMessage(hwndParent, FS_GETFILESPEC, COUNTOF(szPath)-uStrLen,
-                     (LPARAM)(szPath+uStrLen));
+         SendMessage(hwndParent, FS_GETFILESPEC, COUNTOF(szFileSpec),
+                     (LPARAM)szFileSpec);
+         lstrcat(szPath, szFileSpec);
 
          if (hwndDir = HasDirWindow(hwndParent)) {
 

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -503,7 +503,7 @@ CreateTreeWindow(
 
 HWND
 CreateDirWindow(
-   register LPWSTR szPath,
+   LPWSTR szPath,
    BOOL bReplaceOpen,
    HWND hwndActive)
 {
@@ -550,8 +550,11 @@ CreateDirWindow(
 
 	   if (hwndT = HasDirWindow(hwndActive))
 	   {
+		   WCHAR szFileSpec[MAXPATHLEN];
+
 		   AddBackslash(szPath);                   // default to all files
-		   SendMessage(hwndT, FS_GETFILESPEC, MAXFILENAMELEN, (LPARAM)(szPath + lstrlen(szPath)));
+		   SendMessage(hwndT, FS_GETFILESPEC, COUNTOF(szFileSpec), (LPARAM)szFileSpec);
+		   lstrcat(szPath, szFileSpec);
 		   SendMessage(hwndT, FS_CHANGEDISPLAY, CD_PATH, (LPARAM)szPath);
 		   StripFilespec(szPath);
 	   }
@@ -601,7 +604,7 @@ OpenOrEditSelection(HWND hwndActive, BOOL fEdit)
    DWORD ret;
    HCURSOR hCursor;
 
-   WCHAR szPath[MAXPATHLEN+2];  // +2 for quotes if needed
+   WCHAR szPath[MAXPATHLEN + 2];  // +2 for quotes if needed
 
    HWND hwndTree, hwndDir, hwndFocus;
 

--- a/src/wfdrives.c
+++ b/src/wfdrives.c
@@ -561,7 +561,7 @@ DrivesSetDrive(
    DRIVEIND driveIndCur,
    BOOL bDontSteal)
 {
-   WCHAR szPath[MAXPATHLEN];
+   WCHAR szPath[MAXPATHLEN * 2];
 
    HWND hwndChild;
    HWND hwndTree;
@@ -638,11 +638,10 @@ DrivesSetDrive(
    //
    if (hwndDir = HasDirWindow(hwndChild)) {
 
-     WCHAR szFileSpec[MAXPATHLEN];
-     
+     UINT iStrLen;
      AddBackslash(szPath);
-     SendMessage(hwndDir, FS_GETFILESPEC, COUNTOF(szFileSpec), (LPARAM)szFileSpec);
-     lstrcat(szPath, szFileSpec);
+     iStrLen = lstrlen(szPath);
+     SendMessage(hwndDir, FS_GETFILESPEC, COUNTOF(szPath) - iStrLen, (LPARAM)(szPath + iStrLen));
 
      SendMessage(hwndDir, FS_CHANGEDISPLAY,
         bDontSteal ? CD_PATH_FORCE | CD_DONTSTEAL : CD_PATH_FORCE,

--- a/src/wfdrives.c
+++ b/src/wfdrives.c
@@ -561,7 +561,7 @@ DrivesSetDrive(
    DRIVEIND driveIndCur,
    BOOL bDontSteal)
 {
-   WCHAR szPath[MAXPATHLEN * 2];
+   WCHAR szPath[MAXPATHLEN];
 
    HWND hwndChild;
    HWND hwndTree;
@@ -638,8 +638,11 @@ DrivesSetDrive(
    //
    if (hwndDir = HasDirWindow(hwndChild)) {
 
+     WCHAR szFileSpec[MAXPATHLEN];
+     
      AddBackslash(szPath);
-     SendMessage(hwndDir, FS_GETFILESPEC, MAXFILENAMELEN, (LPARAM)(szPath + lstrlen(szPath)));
+     SendMessage(hwndDir, FS_GETFILESPEC, COUNTOF(szFileSpec), (LPARAM)szFileSpec);
+     lstrcat(szPath, szFileSpec);
 
      SendMessage(hwndDir, FS_CHANGEDISPLAY,
         bDontSteal ? CD_PATH_FORCE | CD_DONTSTEAL : CD_PATH_FORCE,

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -363,7 +363,7 @@ VOID vWaitMessage();
 VOID RedoDriveWindows(HWND);
 BOOL FmifsLoaded(VOID);
 VOID  ChangeFileSystem(DWORD dwOper, LPWSTR lpPath, LPWSTR lpTo);
-HWND  CreateDirWindow(register LPWSTR szPath, BOOL bReplaceOpen, HWND hwndActive);
+HWND  CreateDirWindow(LPWSTR szPath, BOOL bReplaceOpen, HWND hwndActive);
 HWND CreateTreeWindow(LPWSTR szPath, INT x, INT y, INT dx, INT dy, INT dxSplit);
 VOID SwitchToSafeDrive();
 DWORD ReadMoveStatus();


### PR DESCRIPTION
### General
FS_GETFILESPEC caused buffer overflows on too small buffers in 3 places:

wfcomman.c
wfdrives.c
FS_GETFILESPEC was called with e.g. MAXFILENAMELEN, but the start of the WCHAR was moved back by lstrlen(szPath), thus causing a buffer overflow.

treectl.c
FS_GETFILESPEC was called correctly but when this was executed close to 256 chars it failed in getting the filespec, because the string was truncated @MAXFILENAMELEN

### Detail
- If you follow e.g the path from OpenOrEditSelection() it begins with allocating szPath with MAXPATHLEN+2. 
- In wfcomman:674 CreateDirWindow() is called with szPath, which still is fine, 
- in wfcomman.c:554 the already partially filled szPath is taken, and handed over to FS_GETFILESPEC with MAXFILENAMELEN. 
- FS_GETFILESPEC is now allowed to append MAXFILENAMELEN to szPath (it really does this), which already contains e.g. 230 characters, and which definitely causes a buffer overflow.

The symptoms of this problem were already smelled by the authors, because in many places the path for CreateDirWindow() was already MAXPATHLEN * 2. 

This issue is a problem when path are longer than 128 characters, but nowadays this happens often.

The same ugly (szPath + lstrlen(szPath) pattern was used in 2 other places, where I also fixed it. Well in treectl.c it didn't crash, but having path longer than 128 char caused a problem, because path were truncated to MAXPATHLEN