### PR TITLE
Search shall not stop on a network drive with ERROR_SYMLINK_CLASS_DIS…

### DIFF
--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -712,6 +712,7 @@ CreateDTABlockWorker(
       //
       if (ERROR_PATH_NOT_FOUND == lfndta.err ||
          ERROR_INVALID_REPARSE_DATA == lfndta.err ||
+         ERROR_SYMLINK_CLASS_DISABLED == lfndta.err ||
          ERROR_CANT_ACCESS_FILE == lfndta.err) {
 
          iError = IDS_BADPATHMSG;
@@ -734,6 +735,7 @@ CreateDTABlockWorker(
          case ERROR_PATH_NOT_FOUND:
          case ERROR_CANT_ACCESS_FILE:
          case ERROR_INVALID_REPARSE_DATA:
+         case ERROR_SYMLINK_CLASS_DISABLED:
 
 InvalidDirectory:
 

--- a/src/wfsearch.c
+++ b/src/wfsearch.c
@@ -230,6 +230,7 @@ MemoryError:
          ERROR_PATH_NOT_FOUND != lfndta.err &&
          ERROR_INVALID_REPARSE_DATA != lfndta.err &&
          ERROR_CANT_ACCESS_FILE != lfndta.err &&
+         ERROR_SYMLINK_CLASS_DISABLED != lfndta.err &&
          ERROR_INVALID_NAME != lfndta.err)) {
 
       SearchInfo.eStatus = SEARCH_ERROR;


### PR DESCRIPTION
### General
Performing a search for e.g. pingme.txt in Users\ on a drive, which is mapped to \\machine\c$, stops midway without result and shows the error message ERROR_SYMLINK_CLASS_DISABLED.

### Solution
Take care of this error code during search. This is similar to #319 