### PR TITLE
Show more than 10 results from goto cache

### DIFF
--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -523,7 +523,8 @@ VOID UpdateGotoList(HWND hDlg)
 	if (options.empty())
 		return;
 
-	for (auto i = 0u; i < 10u && i < options.size(); i++)
+	constexpr int maxResults = 1000;
+	for (size_t i = 0; i < maxResults && i < options.size(); i++)
 	{
 		GetTreePath(options.at(i), szText);
 
@@ -534,7 +535,7 @@ VOID UpdateGotoList(HWND hDlg)
 	{
 		SendMessage(hwndLB, LB_ADDSTRING, 0, (LPARAM)TEXT("... limited ..."));
 	}
-	else if (options.size() >= 10)
+	else if (options.size() >= maxResults)
 	{
 		SendMessage(hwndLB, LB_ADDSTRING, 0, (LPARAM)TEXT("... more ..."));
 	}

--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -523,7 +523,7 @@ VOID UpdateGotoList(HWND hDlg)
 	if (options.empty())
 		return;
 
-	constexpr int maxResults = 1000;
+	constexpr int maxResults = 500;
 	for (size_t i = 0; i < maxResults && i < options.size(); i++)
 	{
 		GetTreePath(options.at(i), szText);


### PR DESCRIPTION
Currently Winfile only shows 10 results from the Goto Cache search after CTRL-G

This is many times not enough, so increased it
