### PR TITLE
Fix x64 warning about incremental linking with COMDAT folding

### DIFF
--- a/src/Winfile.vcxproj
+++ b/src/Winfile.vcxproj
@@ -100,7 +100,7 @@
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\</IntDir>
-    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />


### PR DESCRIPTION
I've been getting warnings recently on x64 about incompatible linking options, which probably occurred as part of the 2019 compiler upgrade.  The warning is complaining about using `/INCREMENTAL` with `/OPT:ICF`.  I think incremental is odd, since this is used for Debug but not Release builds on x86 and arm64, but for some reason x64 uses incremental linking on Release too.  So this resolves the warning by making x64 linking consistent with the others.