### PR TITLE
Fixes for clang

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,7 +36,7 @@ SRCS = \
 OBJS = $(subst .c,.o,$(SRCS)) src/wfgoto.o src/res.o
 
 CFLAGS = -DUNICODE -DFASTMOVE -DSTRSAFE_NO_DEPRECATE -DWINVER=0x0600
-LDLIBS = -mwindows -lgdi32 -lcomctl32 -lole32 -lshlwapi -loleaut32 -lversion
+LDLIBS = -mwindows -lkernel32 -lgdi32 -luser32 -ladvapi32 -lcomctl32 -lole32 -lshlwapi -lshell32 -loleaut32 -lversion
 TARGET = winfile
 ifeq ($(OS),Windows_NT)
 TARGET := $(TARGET).exe

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -21,7 +21,7 @@
 #include <memory.h>
 #include "mpr.h"
 #include <npapi.h>
-#include <wfext.h>
+#include "wfext.h"
 #include <commdlg.h>
 #include <commctrl.h>
 #include "fmifs.h"


### PR DESCRIPTION
This fixes two minor things so clang can compile cleanly:

- Explicitly list all libraries being linked against to avoid unresolved externals
- Change the header brace style for a header that's included in the source tree that's not in the include path