### PR TITLE
Remove register keyword which is obsolete

### DIFF
--- a/src/treectl.c
+++ b/src/treectl.c
@@ -37,7 +37,7 @@ DWORD cNodes;
 VOID
 GetTreePathIndirect(
     PDNODE pNode,
-    register LPTSTR szDest);
+    LPTSTR szDest);
 
 VOID
 ScanDirLevel(
@@ -136,9 +136,9 @@ int GetDragStatusText(int iOperation)
 /*--------------------------------------------------------------------------*/
 
 VOID
-GetTreePathIndirect(PDNODE pNode, register LPTSTR szDest)
+GetTreePathIndirect(PDNODE pNode, LPTSTR szDest)
 {
-   register PDNODE    pParent;
+   PDNODE    pParent;
 
    pParent = pNode->pParent;
 
@@ -161,7 +161,7 @@ GetTreePathIndirect(PDNODE pNode, register LPTSTR szDest)
 /*--------------------------------------------------------------------------*/
 
 VOID
-GetTreePath(PDNODE pNode, register LPTSTR szDest)
+GetTreePath(PDNODE pNode, LPTSTR szDest)
 {
    szDest[0] = CHAR_NULL;
    GetTreePathIndirect(pNode, szDest);
@@ -1331,8 +1331,8 @@ FindItemFromPath(
    DWORD *pIndex,
    PDNODE *ppNode)
 {
-  register DWORD     i;
-  register LPTSTR    p;
+  DWORD              i;
+  LPTSTR             p;
   PDNODE             pNode;
   DWORD              iPreviousNode;
   PDNODE             pPreviousNode;
@@ -2086,7 +2086,7 @@ ExpandLevel(HWND hWnd, WPARAM wParam, INT nIndex, LPTSTR szPath)
 LRESULT
 CALLBACK
 TreeControlWndProc(
-   register HWND hwnd,
+   HWND hwnd,
    UINT uMsg,
    WPARAM wParam,
    LPARAM lParam)

--- a/src/treectl.h
+++ b/src/treectl.h
@@ -33,5 +33,5 @@ typedef struct tagDNODE
   } DNODE;
 typedef DNODE *PDNODE;
 
-VOID GetTreePath(PDNODE pNode, register LPTSTR szDest);
+VOID GetTreePath(PDNODE pNode, LPTSTR szDest);
 VOID SetNodeAttribs(PDNODE pNode, LPTSTR szPath);

--- a/src/wfassoc.c
+++ b/src/wfassoc.c
@@ -142,7 +142,7 @@ PEXT pExtBase = NULL;
 
 // Prototypes
 
-INT_PTR CALLBACK AssociateFileDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
+INT_PTR CALLBACK AssociateFileDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
 BOOL AssociateDlgInit(HWND hDlg, LPTSTR lpszExt, INT iSel);
 BOOL AssociateFileDlgExtAdd(HWND hDlg, PASSOCIATEFILEDLGINFO pAssociateFileDlgInfo);
 BOOL AssociateFileDlgExtDelete(HWND hDlg, PASSOCIATEFILEDLGINFO pAssociateFileDlgInfo);
@@ -412,7 +412,7 @@ UpdateSelectionExt(HWND hDlg, BOOL bForce)
 
 INT_PTR
 CALLBACK
-AssociateDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+AssociateDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
    TCHAR szTemp[STRINGSIZ];
    PFILETYPE pFileType, pft2;
@@ -427,7 +427,7 @@ AssociateDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
    case WM_INITDIALOG:
       {
          LPTSTR p;
-         register LPTSTR pSave;
+         LPTSTR pSave;
          INT iItem;
 
          // Turn off refresh flag (GWL_USERDATA)
@@ -1015,7 +1015,7 @@ DoHelp:
 
 INT_PTR
 CALLBACK
-AssociateFileDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+AssociateFileDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
    INT i;
    DWORD dwError;

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -105,7 +105,7 @@ LocateDirWindow(
     BOOL bNoFileSpec,
     BOOL bNoTreeWindow)
 {
-   register HWND hwndT;
+   HWND hwndT;
    HWND hwndDir;
    LPTSTR pT2;
    TCHAR szTemp[MAXPATHLEN];
@@ -173,7 +173,7 @@ UpdateAllDirWindows(
     DWORD dwFunction,
     BOOL bNoFileSpec)
 {
-   register HWND hwndT;
+   HWND hwndT;
    HWND hwndDir;
    LPTSTR pT2;
    TCHAR szTemp[MAXPATHLEN];
@@ -248,7 +248,7 @@ UpdateAllDirWindows(
 
 VOID
 ChangeFileSystem(
-   register DWORD dwFunction,
+   DWORD dwFunction,
    LPTSTR lpszFile,
    LPTSTR lpszTo)
 {
@@ -507,7 +507,7 @@ CreateDirWindow(
    BOOL bReplaceOpen,
    HWND hwndActive)
 {
-   register HWND hwndT;
+   HWND hwndT;
    INT dxSplit;
 
    if (hwndActive == hwndSearch) {
@@ -882,11 +882,11 @@ BOOL GetBashExePath(LPTSTR szBashPath, UINT bufSize)
 /*--------------------------------------------------------------------------*/
 
 BOOL
-AppCommandProc(register DWORD id)
+AppCommandProc(DWORD id)
 {
    DWORD         dwFlags;
    HMENU         hMenu;
-   register HWND hwndActive;
+   HWND          hwndActive;
    BOOL          bTemp;
    HWND          hwndT;
    TCHAR         szPath[MAXPATHLEN];

--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -32,14 +32,14 @@ DWORD ConfirmDialog(
    BOOL bConfirmByDefault, BOOL *pbAll,
    BOOL bConfirmReadOnlyByDefault, BOOL *pbReadOnlyAll);
 
-DWORD IsInvalidPath(register LPTSTR pPath);
-DWORD GetNextPair(register PCOPYROOT pcr, LPTSTR pFrom, LPTSTR pToPath, LPTSTR pToSpec, DWORD dwFunc, PDWORD pdwError, BOOL bIsLFNDriveDest);
+DWORD IsInvalidPath(LPTSTR pPath);
+DWORD GetNextPair(PCOPYROOT pcr, LPTSTR pFrom, LPTSTR pToPath, LPTSTR pToSpec, DWORD dwFunc, PDWORD pdwError, BOOL bIsLFNDriveDest);
 INT  CheckMultiple(LPTSTR pInput);
-VOID DialogEnterFileStuff(register HWND hwnd);
+VOID DialogEnterFileStuff(HWND hwnd);
 DWORD SafeFileRemove(LPTSTR szFileOEM);
 BOOL IsWindowsFile(LPTSTR szFileOEM);
 
-INT_PTR CALLBACK ReplaceDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
+INT_PTR CALLBACK ReplaceDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
 
 
 BOOL
@@ -84,9 +84,9 @@ IsValidChar(TUCHAR ch, BOOL fPath, BOOL bLFN)
 //--------------------------------------------------------------------------
 
 LPTSTR
-StripColon(register LPTSTR pPath)
+StripColon(LPTSTR pPath)
 {
-   register INT cb = lstrlen(pPath);
+   INT cb = lstrlen(pPath);
 
    if (cb > 2 && pPath[cb-1] == CHAR_COLON)
       pPath[cb-1] = CHAR_NULL;
@@ -103,9 +103,9 @@ StripColon(register LPTSTR pPath)
 /* Returns a pointer to the last component of a path string. */
 
 LPTSTR
-FindFileName(register LPTSTR pPath)
+FindFileName(LPTSTR pPath)
 {
-   register LPTSTR pT;
+   LPTSTR pT;
 
    for (pT=pPath; *pPath; pPath++) {
       if ((pPath[0] == CHAR_BACKSLASH || pPath[0] == CHAR_COLON) && pPath[1])
@@ -615,7 +615,7 @@ AddComponent:
 /*--------------------------------------------------------------------------*/
 
 BOOL
-IsRootDirectory(register LPTSTR pPath)
+IsRootDirectory(LPTSTR pPath)
 {
   if (!lstrcmpi(pPath+1, TEXT(":\\")))
       return(TRUE);
@@ -687,11 +687,11 @@ IsDirectory(LPTSTR pPath)
 BOOL 
 IsTheDiskReallyThere(
    HWND hwnd,
-   register LPTSTR pPath,
+   LPTSTR pPath,
    DWORD dwFunc,
    BOOL bModal)
 {
-   register DRIVE drive;
+   DRIVE drive;
    TCHAR szTemp[MAXMESSAGELEN];
    TCHAR szMessage[MAXMESSAGELEN];
    TCHAR szTitle[128];
@@ -941,7 +941,7 @@ SetDlgItemPath(HWND hDlg, INT id, LPTSTR pszPath)
 
 INT_PTR
 CALLBACK
-ReplaceDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+ReplaceDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
    WCHAR szMessage[MAXMESSAGELEN];
 
@@ -1155,7 +1155,7 @@ NetCheck(LPTSTR pPath, DWORD dwType)
  */
 
 DWORD
-IsInvalidPath(register LPTSTR pPath)
+IsInvalidPath(LPTSTR pPath)
 {
   TCHAR  sz[9];
   INT   n = 0;
@@ -1887,7 +1887,7 @@ IsCurrentDirectory (LPTSTR p)
 //
 
 INT
-CheckMultiple(register LPTSTR pInput)
+CheckMultiple(LPTSTR pInput)
 {
   LPTSTR pT;
   TCHAR szTemp[MAXPATHLEN];
@@ -1921,9 +1921,9 @@ CheckMultiple(register LPTSTR pInput)
 /* Prevents the user from diddling anything other than the cancel button. */
 
 VOID
-DialogEnterFileStuff(register HWND hwnd)
+DialogEnterFileStuff(HWND hwnd)
 {
-   register HWND hwndT;
+   HWND hwndT;
 
    //
    // set the focus to the cancel button so the user can hit space or esc
@@ -3392,8 +3392,8 @@ ExitLoop:
 
 DWORD
 DMMoveCopyHelper(
-   register LPTSTR pFrom,
-   register LPTSTR pTo,
+   LPTSTR pFrom,
+   LPTSTR pTo,
    INT iOperation)
 {
    DWORD       dwStatus;

--- a/src/wfcopy.h
+++ b/src/wfcopy.h
@@ -56,5 +56,5 @@ VOID AppendToPath(LPTSTR,LPCTSTR);
 UINT RemoveLast(LPTSTR pFile);
 VOID Notify(HWND,WORD,LPTSTR,LPTSTR);
 
-LPTSTR FindFileName(register LPTSTR pPath);
+LPTSTR FindFileName(LPTSTR pPath);
 

--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -32,9 +32,9 @@ typedef struct _SELINFO {
 
 VOID RightTabbedTextOut(HDC hdc, INT x, INT y, LPWSTR pLine, WORD *pTabStops, INT x_offset, DWORD dwAlternateFileNameExtent);
 LRESULT ChangeDisplay(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-INT CompareDTA(register LPXDTA lpItem1, register LPXDTA lpItem2, DWORD dwSort);
+INT CompareDTA(LPXDTA lpItem1, LPXDTA lpItem2, DWORD dwSort);
 BOOL SetDirFocus(HWND hwndDir);
-VOID DirGetAnchorFocus(register HWND hwndLB, LPXDTALINK lpStart, PSELINFO pSelInfo);
+VOID DirGetAnchorFocus(HWND hwndLB, LPXDTALINK lpStart, PSELINFO pSelInfo);
 BOOL SetSelection(HWND hwndLB, LPXDTALINK lpStart, LPWSTR pszSel);
 INT DirFindIndex(HWND hwndLB, LPXDTALINK lpStart, LPTSTR lpszFile);
 VOID SortDirList(HWND hwndDir, LPXDTALINK lpStart, DWORD count, LPXDTA* lplpxdta);
@@ -311,9 +311,9 @@ FocusOnly:
 /////////////////////////////////////////////////////////////////////
 
 VOID
-CreateLBLine(register DWORD dwLineFormat, LPXDTA lpxdta, LPWSTR szBuffer)
+CreateLBLine(DWORD dwLineFormat, LPXDTA lpxdta, LPWSTR szBuffer)
 {
-   register LPWSTR pch;
+   LPWSTR pch;
    DWORD dwAttr;
 
    pch = szBuffer;
@@ -1727,7 +1727,7 @@ GetPict(
    WCHAR ch,
    LPCWSTR pszStr)
 {
-   register UINT  count;
+   UINT  count;
 
    count = 0;
    while (ch == *pszStr++)
@@ -1974,8 +1974,8 @@ PutTime(
 
 INT
 PutAttributes(
-   register DWORD dwAttribute,
-   register LPWSTR pszStr)
+   DWORD dwAttribute,
+   LPWSTR pszStr)
 {
    INT   cch = 0;
 
@@ -2440,7 +2440,7 @@ FillDirList(
    HWND hwndDir,
    LPXDTALINK lpStart)
 {
-   register DWORD count;
+   DWORD count;
    UINT   i;
    LPXDTAHEAD lpHead;
    INT iError;
@@ -2515,11 +2515,11 @@ Error:
 
 INT
 CompareDTA(
-   register LPXDTA lpItem1,
-   register LPXDTA lpItem2,
+   LPXDTA lpItem1,
+   LPXDTA lpItem2,
    DWORD dwSort)
 {
-   register INT  ret;
+   INT  ret;
 
    if (!lpItem1 || !lpItem2)
       return lpItem1 ? 1 : -1;
@@ -2989,7 +2989,7 @@ GDSDone:
 INT
 DirFindIndex(HWND hwndLB, LPXDTALINK lpStart, LPWSTR lpszFile)
 {
-   register INT i;
+   INT i;
    DWORD dwSel;
    LPXDTA lpxdta;
 
@@ -3025,11 +3025,11 @@ DirFindIndex(HWND hwndLB, LPXDTALINK lpStart, LPWSTR lpszFile)
 
 VOID
 DirGetAnchorFocus(
-   register HWND hwndLB,
+   HWND hwndLB,
    LPXDTALINK lpStart,
    PSELINFO pSelInfo)
 {
-   register INT iSel, iCount;
+   INT iSel, iCount;
    LPXDTA   lpxdta;
 
    iSel = (INT)SendMessage(hwndLB, LB_GETANCHORINDEX, 0, 0L);

--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -296,7 +296,7 @@ StealDTABlock(
 VOID
 FreeDTA(HWND hwnd)
 {
-   register LPXDTALINK lpxdtaLink;
+   LPXDTALINK lpxdtaLink;
 
    lpxdtaLink = (LPXDTALINK)GetWindowLongPtr(hwnd, GWL_HDTA);
 
@@ -436,8 +436,8 @@ BuildDocumentString()
 VOID
 BuildDocumentStringWorker()
 {
-   register LPTSTR   p;
-   register INT      uLen;
+   LPTSTR            p;
+   INT               uLen;
    TCHAR             szT[EXTSIZ + 1];
    INT               i,j;
    LPTSTR            pszDocuments = NULL;
@@ -647,7 +647,7 @@ CreateDTABlockWorker(
    HWND hwnd,
    HWND hwndDir)
 {
-   register LPWSTR pName;
+   LPWSTR pName;
    PDOCBUCKET pDoc, pProgram;
 
    LFNDTA lfndta;

--- a/src/wfdlgs.c
+++ b/src/wfdlgs.c
@@ -138,10 +138,10 @@ DO_AGAIN:
 
 INT_PTR
 CALLBACK
-OtherDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+OtherDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
   DWORD          dwView;
-  register HWND hwndActive;
+  HWND           hwndActive;
 
   UNREFERENCED_PARAMETER(lParam);
 
@@ -808,8 +808,8 @@ DoHelp:
 VOID
 KillQuoteTrailSpace( LPTSTR szFile )
 {
-   register LPTSTR pc;
-   register LPTSTR pcNext;
+   LPTSTR pc;
+   LPTSTR pcNext;
    LPTSTR pcLastSpace = NULL;
 
    // Could reuse szFile, but that's ok,

--- a/src/wfdlgs2.c
+++ b/src/wfdlgs2.c
@@ -104,7 +104,7 @@ StarFilename(LPTSTR pszPath)
 
 INT_PTR
 CALLBACK
-SearchDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+SearchDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
    LPTSTR     p;
    MDICREATESTRUCT   MDICS;
@@ -259,7 +259,7 @@ CALLBACK
 RunDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
   LPTSTR p,pDir,pFile,pPar;
-  register DWORD ret;
+  DWORD ret;
   LPTSTR pDir2;
   TCHAR szTemp[MAXPATHLEN];
   TCHAR szTemp2[MAXPATHLEN];
@@ -416,7 +416,7 @@ MessWithRenameDirPath(LPTSTR pszPath)
 
 INT_PTR
 CALLBACK
-SuperDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+SuperDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
    UINT          len;
    INT           iCtrl;
@@ -1645,7 +1645,7 @@ FullPath:
 
 INT_PTR
 CALLBACK
-AttribsDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+AttribsDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
    LPTSTR p, pSel;
    BOOL bRet;

--- a/src/wfdlgs3.c
+++ b/src/wfdlgs3.c
@@ -48,7 +48,7 @@ typedef enum {
 
 INT_PTR
 CALLBACK
-ChooseDriveDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+ChooseDriveDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
    TCHAR szDrive[5];
 
@@ -157,7 +157,7 @@ DoHelp:
 
 INT_PTR
 CALLBACK
-DiskLabelDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+DiskLabelDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
    TCHAR szNewVol[MAXPATHLEN];
    LPTSTR lpszVol;
@@ -513,7 +513,7 @@ FillDriveCapacity(HWND hDlg, INT nDrive, FMIFS_MEDIA_TYPE fmSelect, BOOL fDoPopu
 
 INT_PTR
 CALLBACK
-FormatDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+FormatDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
    TCHAR szBuf[128];
    INT  i, count;
@@ -741,7 +741,7 @@ DoHelp:
 
 INT_PTR
 CALLBACK
-FormatSelectDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+FormatSelectDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
     HWND  hwndSelectDrive;
     INT   driveIndex;
@@ -829,7 +829,7 @@ FormatSelectDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 
 INT_PTR
 CALLBACK
-AboutDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+AboutDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
     WORD wMajorVersion   = 0;
     WORD wMinorVersion   = 0;
@@ -1306,7 +1306,7 @@ CancelDlgProc(HWND hDlg,
 
 INT_PTR
 CALLBACK
-ProgressDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
+ProgressDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
    static PCOPYINFO pCopyInfo;
    TCHAR szTitle[MAXTITLELEN];

--- a/src/wffile.c
+++ b/src/wffile.c
@@ -1708,7 +1708,7 @@ BOOL GetRootPath(
 //
 /////////////////////////////////////////////////////////////////////////////
 
-extern VOID GetTreePath(PDNODE pNode, register LPTSTR szDest);
+extern VOID GetTreePath(PDNODE pNode, LPTSTR szDest);
 
 VOID RedrawAllTreeWindows()
 {

--- a/src/wfinfo.c
+++ b/src/wfinfo.c
@@ -789,7 +789,7 @@ DocOpenEnum(PPDOCBUCKET ppDocBucket)
 /////////////////////////////////////////////////////////////////////
 
 LPTSTR
-DocEnum(register PDOCENUM pDocEnum, PHICON phIcon)
+DocEnum(PDOCENUM pDocEnum, PHICON phIcon)
 {
    LPTSTR pszExt;
 
@@ -1388,7 +1388,7 @@ EnumRetry:
 DWORD
 WFGetConnection(DRIVE drive, LPTSTR* ppPath, BOOL bConvertClosed, DWORD dwType)
 {
-   register DWORD dwRetVal;
+   DWORD dwRetVal;
    BOOL bConverted = FALSE;
 
    //

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -33,7 +33,7 @@ TCHAR szHelv[] = TEXT("MS Shell Dlg");
 HBITMAP hbmSave;
 
 DWORD   RGBToBGR(DWORD rgb);
-VOID    BoilThatDustSpec(register WCHAR *pStart, BOOL bLoadIt);
+VOID    BoilThatDustSpec(WCHAR *pStart, BOOL bLoadIt);
 VOID    DoRunEquals(PINT pnCmdShow);
 VOID    GetSavedWindow(LPWSTR szBuf, PWINDOW pwin);
 VOID    GetSettings(VOID);
@@ -293,7 +293,7 @@ GetInternational()
 
 
 INT
-GetDriveOffset(register DRIVE drive)
+GetDriveOffset(DRIVE drive)
 {
    if (IsRemoteDrive(drive)) {
 
@@ -512,9 +512,9 @@ UINT  MapMenuPosToIDM(UINT pos)
  */
 
 VOID
-BoilThatDustSpec(register TCHAR *pStart, BOOL bLoadIt)
+BoilThatDustSpec(TCHAR *pStart, BOOL bLoadIt)
 {
-   register TCHAR *pEnd;
+   TCHAR *       pEnd;
    DWORD         ret;
    BOOL          bFinished;
 

--- a/src/wfmem.c
+++ b/src/wfmem.c
@@ -286,9 +286,9 @@ MemClone(LPXDTALINK lpStart)
 }
 
 LPXDTA
-MemNext(register LPXDTALINK* plpLink, register LPXDTA lpxdta)
+MemNext(LPXDTALINK* plpLink, LPXDTA lpxdta)
 {
-   register LPXDTALINK lpLinkCur = *plpLink;
+   LPXDTALINK lpLinkCur = *plpLink;
 
    if ((PBYTE)lpxdta + lpxdta->dwSize - (PBYTE)lpLinkCur == (INT)lpLinkCur->dwNextFree)
    {

--- a/src/wfsearch.c
+++ b/src/wfsearch.c
@@ -423,7 +423,7 @@ FixUpFileSpec(
    LPWSTR szFileSpec)
 {
   WCHAR szTemp[MAXPATHLEN+1];
-  register LPWSTR p;
+  LPWSTR p;
 
   if (*szFileSpec == CHAR_DOT) {
     lstrcpy(szTemp, SZ_STAR);
@@ -599,7 +599,7 @@ UpdateSearchStatus(HWND hwndLB, INT nCount)
 LRESULT
 CALLBACK
 SearchWndProc(
-   register HWND hwnd,
+   HWND hwnd,
    UINT uMsg,
    WPARAM wParam,
    LPARAM lParam)

--- a/src/wftree.c
+++ b/src/wftree.c
@@ -82,7 +82,7 @@ GetTreeFocus(HWND hwndTree)
 BOOL
 CompactPath(HDC hDC, LPTSTR lpszPath, DWORD dx)
 {
-   register INT  len;
+   INT           len;
    SIZE          sizeF, sizeT;
    LPTSTR        lpEnd;          /* end of the unfixed string */
    LPTSTR        lpFixed;        /* start of text that we always display */
@@ -351,9 +351,9 @@ SwitchDriveSelection(HWND hwndChild, BOOL bSelectToolbarDrive)
 LRESULT
 CALLBACK
 TreeWndProc(
-   register HWND hwnd,
+   HWND hwnd,
    UINT uMsg,
-   register WPARAM wParam,
+   WPARAM wParam,
    LPARAM lParam)
 {
    HWND hwndTree, hwndDir, hwndFocus;

--- a/src/wfutil.c
+++ b/src/wfutil.c
@@ -843,7 +843,7 @@ IsNetDrive(INT drive)
 #endif
 
 BOOL
-IsNTFSDrive(register DRIVE drive)
+IsNTFSDrive(DRIVE drive)
 {
    U_VolInfo(drive);
 
@@ -868,7 +868,7 @@ IsNTFSDrive(register DRIVE drive)
 //            If it is NOT a FAT drive, it returns TRUE.
 //
 BOOL
-IsCasePreservedDrive(register DRIVE drive)
+IsCasePreservedDrive(DRIVE drive)
 {
    U_VolInfo(drive);
 
@@ -896,14 +896,14 @@ IsCasePreservedDrive(register DRIVE drive)
 
 
 BOOL
-IsRemovableDrive(register DRIVE drive)
+IsRemovableDrive(DRIVE drive)
 {
    return aDriveInfo[drive].uType == DRIVE_REMOVABLE;
 }
 
 
 BOOL
-IsRemoteDrive(register DRIVE drive)
+IsRemoteDrive(DRIVE drive)
 {
    return aDriveInfo[drive].uType == DRIVE_REMOTE;
 }
@@ -1244,7 +1244,7 @@ CheckSlashes(LPTSTR lpT)
 UINT
 AddBackslash(LPTSTR lpszPath)
 {
-   register UINT uLen = lstrlen(lpszPath);
+   UINT uLen = lstrlen(lpszPath);
 
    if (*(lpszPath+uLen-1) != CHAR_BACKSLASH) {
 
@@ -1269,7 +1269,7 @@ AddBackslash(LPTSTR lpszPath)
 VOID
 StripBackslash(LPTSTR lpszPath)
 {
-  register UINT len;
+  UINT len;
 
   len = (lstrlen(lpszPath) - 1);
   if ((len == 2) || (lpszPath[len] != CHAR_BACKSLASH))

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -435,14 +435,14 @@ BOOL GetPrevHistoryDir(BOOL forward, HWND *phwnd, LPWSTR szDir);
 VOID   UpdateStatus(HWND hWnd);
 LPWSTR DirGetSelection(HWND hwndDir, HWND hwndView, HWND hwndLB, INT iSelType, BOOL *pfDir, PINT piLastSel);
 VOID   FillDirList(HWND hwndDir, LPXDTALINK lpStart);
-VOID   CreateLBLine(register DWORD dwLineFormat, LPXDTA lpxdta, LPTSTR szBuffer);
+VOID   CreateLBLine(DWORD dwLineFormat, LPXDTA lpxdta, LPTSTR szBuffer);
 INT    GetMaxExtent(HWND hwndLB, LPXDTALINK lpXDTA, BOOL bNTFS);
 VOID   UpdateSelection(HWND hwndLB);
 
 INT  PutDate(LPFILETIME lpftDate, LPTSTR szStr);
 INT  PutTime(LPFILETIME lpftTime, LPTSTR szStr);
 INT  PutSize(PLARGE_INTEGER pqSize, LPTSTR szOutStr);
-INT  PutAttributes(register DWORD dwAttribute, register LPTSTR szStr);
+INT  PutAttributes(DWORD dwAttribute, LPTSTR szStr);
 HWND GetMDIChildFromDescendant(HWND hwnd);
 VOID SetLBFont(HWND hwnd, HWND hwndLB, HANDLE hNewFont, DWORD dwViewFlags, LPXDTALINK lpStart);
 
@@ -503,7 +503,7 @@ VOID  FreeFileManager(VOID);
 VOID  DeleteBitmaps(VOID);
 BOOL  CreateSavedWindows(VOID);
 VOID  InitExtensions(VOID);
-INT   GetDriveOffset(register DRIVE drive);
+INT   GetDriveOffset(DRIVE drive);
 VOID  InitMenus(VOID);
 UINT  MapIDMToMenuPos(UINT idm);
 UINT  MapMenuPosToIDM(UINT pos);
@@ -521,13 +521,13 @@ DWORD  WFMoveCopyDriver(PCOPYINFO pCopyInfo);
 DWORD WINAPI WFMoveCopyDriverThread(LPVOID lpParameter);
 
 BOOL  IsDirectory(LPTSTR pPath);
-BOOL  IsTheDiskReallyThere(HWND hwnd, register LPTSTR pPath, DWORD wFunc, BOOL bModal);
+BOOL  IsTheDiskReallyThere(HWND hwnd, LPTSTR pPath, DWORD wFunc, BOOL bModal);
 BOOL  QualifyPath(LPTSTR);
 INT   CheckMultiple(LPTSTR pInput);
 VOID  SetDlgItemPath(HWND hDlg, INT id, LPTSTR pszPath);
 DWORD NetCheck(LPTSTR pPath, DWORD dwType);
 
-VOID DialogEnterFileStuff(register HWND hwnd);
+VOID DialogEnterFileStuff(HWND hwnd);
 
 
 // WFUTIL.C
@@ -591,7 +591,7 @@ INT_PTR CALLBACK DiskLabelDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lP
 INT_PTR CALLBACK ChooseDriveDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK FormatDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK FormatSelectDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
-INT_PTR CALLBACK OtherDlgProc(register HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
+INT_PTR CALLBACK OtherDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
 
 INT_PTR CALLBACK ProgressDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK SortByDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
@@ -659,7 +659,7 @@ DWORD WFJunction(LPCWSTR LinkDirectory, LPCWSTR LinkTarget);
 VOID  wfYield(VOID);
 VOID  InvalidateAllNetTypes(VOID);
 VOID  GetTreeUNCName(HWND hwndTree, LPTSTR szBuf, INT nBuf);
-BOOL  RectTreeItem(HWND hwndLB, register INT iItem, BOOL bFocusOn);
+BOOL  RectTreeItem(HWND hwndLB, INT iItem, BOOL bFocusOn);
 
 
 


### PR DESCRIPTION
Compiling with clang generates some new warnings.  One of these is the use of the `register` keyword.  As far as I know and have been able to find out, this has been ignored by all 32 bit and 64 bit compilers.  The winfile code appears to depend on this keyword being ignored, because it includes this keyword on parameters used by callback functions where the calling convention is defined by the operating system.

The x64 calling convention uses four registers for the first four parameters and has more registers available for locals, which has rendered this keyword more thoroughly obsolete.