### PR TITLE
Move start options to a submenu to avoid hotkey overloading

### DIFF
--- a/src/lang/res_de-DE.rc
+++ b/src/lang/res_de-DE.rc
@@ -36,10 +36,13 @@ BEGIN
     MENUITEM    "Ver&zeichnis erstellen...\tUmschalt+Strg+N",     IDM_MAKEDIR
     MENUITEM    "&Suchen...\tStrg+F",                             IDM_SEARCH
     MENUITEM    "Dateien aus&wählen...",                          IDM_SELECT
-    MENUITEM    "Starte Bash Shell...\tStrg+B",                   IDM_STARTBASHSHELL
-    MENUITEM    "Starte Cmd Shel&l...\tStrg+K",                   IDM_STARTCMDSHELL
-    MENUITEM    "Starte Po&werShell...\tStrg+P",                  IDM_STARTPOWERSHELL
-    MENUITEM    "Starte E&xplorer...\tCtrl+E",                    IDM_STARTEXPLORER
+    POPUP       "Starte (&.)"
+    BEGIN
+    MENUITEM    "&Bash Shell...\tStrg+B",                         IDM_STARTBASHSHELL
+    MENUITEM    "&Cmd Shell...\tStrg+K",                          IDM_STARTCMDSHELL
+    MENUITEM    "&PowerShell...\tStrg+P",                         IDM_STARTPOWERSHELL
+    MENUITEM    "&Explorer...\tStrg+E",                           IDM_STARTEXPLORER
+    END
     MENUITEM    "&Gehe ins Verzeichnis...\tStrg+G",               IDM_GOTODIR
     MENUITEM    SEPARATOR
     MENUITEM    "&Beenden",                                       IDM_EXIT

--- a/src/lang/res_en-US.rc
+++ b/src/lang/res_en-US.rc
@@ -36,10 +36,13 @@ BEGIN
     MENUITEM    "Cr&eate Directory...\tCtrl+Shift+N", IDM_MAKEDIR
     MENUITEM    "Searc&h...\tCtrl+F",       IDM_SEARCH
     MENUITEM    "Select &Files...", IDM_SELECT
-    MENUITEM    "Start Bash Shell...\tCtrl+B", IDM_STARTBASHSHELL
-    MENUITEM    "Start Cmd Shel&l...\tCtrl+K", IDM_STARTCMDSHELL
-    MENUITEM    "Start Po&werShell...\tCtrl+P", IDM_STARTPOWERSHELL
-    MENUITEM    "Start E&xplorer...\tCtrl+E", IDM_STARTEXPLORER
+    POPUP       "Start (&.)"
+    BEGIN
+    MENUITEM    "&Bash Shell...\tCtrl+B", IDM_STARTBASHSHELL
+    MENUITEM    "&Cmd Shell...\tCtrl+K", IDM_STARTCMDSHELL
+    MENUITEM    "&PowerShell...\tCtrl+P", IDM_STARTPOWERSHELL
+    MENUITEM    "&Explorer...\tCtrl+E", IDM_STARTEXPLORER
+    END
     MENUITEM    "&Goto Directory...\tCtrl+G", IDM_GOTODIR
     MENUITEM    SEPARATOR
     MENUITEM    "E&xit",            IDM_EXIT
@@ -553,7 +556,7 @@ BEGIN
     MH_MYITEMS+IDM_RENAME,      "Renames a file or directory"
     MH_MYITEMS+IDM_ATTRIBS,     "Sets file attributes and displays properties"
     MH_MYITEMS+IDM_UNDELETE,    "Retrieves previously deleted files"
-    MH_MYITEMS+IDM_RUN, "Starts or opens an application or document"
+    MH_MYITEMS+IDM_RUN,         "Starts or opens an application or document"
     MH_MYITEMS+IDM_PRINT,       "Prints a document"
     MH_MYITEMS+IDM_ASSOCIATE,   "Associates a file with an application"
     MH_MYITEMS+IDM_MAKEDIR,     "Creates a directory"

--- a/src/lang/res_he-IL.rc
+++ b/src/lang/res_he-IL.rc
@@ -36,10 +36,13 @@ BEGIN
     MENUITEM    "&יצירת תיקיה...\tCtrl+Shift+N", IDM_MAKEDIR
     MENUITEM    "&חיפוש...\tCtrl+F",       IDM_SEARCH
     MENUITEM    "&בחירת קבצים...", IDM_SELECT
-    MENUITEM    "הפעלת Bash Shell...\tCtrl+B", IDM_STARTBASHSHELL
-    MENUITEM    "הפעלת Cmd Shel&l...\tCtrl+K", IDM_STARTCMDSHELL
-    MENUITEM    "הפעלת Po&werShell...\tCtrl+P", IDM_STARTPOWERSHELL
-    MENUITEM    "הפעלת E&xplorer...\tCtrl+E", IDM_STARTEXPLORER
+    POPUP       "הפעלת (&.)"
+    BEGIN
+    MENUITEM    "הפעלת &Bash Shell...\tCtrl+B", IDM_STARTBASHSHELL
+    MENUITEM    "הפעלת &Cmd Shell...\tCtrl+K", IDM_STARTCMDSHELL
+    MENUITEM    "הפעלת &PowerShell...\tCtrl+P", IDM_STARTPOWERSHELL
+    MENUITEM    "הפעלת &Explorer...\tCtrl+E", IDM_STARTEXPLORER
+    END
     MENUITEM    "עבור לתיקיה...\tCtrl+G", IDM_GOTODIR
     MENUITEM    SEPARATOR
     MENUITEM    "י&ציאה",            IDM_EXIT

--- a/src/lang/res_ja-JP.rc
+++ b/src/lang/res_ja-JP.rc
@@ -36,11 +36,13 @@ BEGIN
     MENUITEM    "ディレクトリを作成(&E)...\tCtrl+Shift+N", IDM_MAKEDIR
     MENUITEM    "検索(&C)...\tCtrl+F",       IDM_SEARCH
     MENUITEM    "ファイルを選択(&F)...", IDM_SELECT
-    MENUITEM    "Bash を起動...\tCtrl+B", IDM_STARTBASHSHELL
-    MENUITEM    "コマンド プロンプトを起動(&L)...\tCtrl+K", IDM_STARTCMDSHELL
-    MENUITEM    "PowerShell を起動(&W)...\tCtrl+P", IDM_STARTPOWERSHELL
-    MENUITEM    "Explorer を起動(&X)...\tCtrl+E", IDM_STARTEXPLORER
-
+    POPUP       "を起動(&.)"
+    BEGIN
+    MENUITEM    "&Bash を起動...\tCtrl+B", IDM_STARTBASHSHELL
+    MENUITEM    "コマンド プロンプトを起動(&C)...\tCtrl+K", IDM_STARTCMDSHELL
+    MENUITEM    "&PowerShell を起動...\tCtrl+P", IDM_STARTPOWERSHELL
+    MENUITEM    "&Explorer を起動...\tCtrl+E", IDM_STARTEXPLORER
+    END
     MENUITEM    "別のディレクトリへ移動(&G)...\tCtrl+G", IDM_GOTODIR
     MENUITEM    SEPARATOR
     MENUITEM    "終了(&X)",            IDM_EXIT

--- a/src/lang/res_pl-PL.rc
+++ b/src/lang/res_pl-PL.rc
@@ -36,10 +36,13 @@ BEGIN
     MENUITEM    "U&twórz katalog...\tCtrl+Shift+N", IDM_MAKEDIR
     MENUITEM    "Szuk&aj...\tCtrl+F",             IDM_SEARCH
     MENUITEM    "&Zaznacz pliki...",              IDM_SELECT
-    MENUITEM    "Uruchom powłokę Bash...\tCtrl+B",      IDM_STARTBASHSHELL
-    MENUITEM    "U&ruchom Wiersz polecenia...\tCtrl+K", IDM_STARTCMDSHELL
-    MENUITEM    "Uruchom Po&werShell...\tCtrl+P",       IDM_STARTPOWERSHELL
-    MENUITEM    "Uruchom E&xplorer...\tCtrl+E", IDM_STARTEXPLORER
+    POPUP       "Uruchom (&.)"
+    BEGIN
+    MENUITEM    "Uruchom powłokę &Bash...\tCtrl+B", IDM_STARTBASHSHELL
+    MENUITEM    "Uruchom Wiersz pole&cenia...\tCtrl+K", IDM_STARTCMDSHELL
+    MENUITEM    "Uruchom &PowerShell...\tCtrl+P", IDM_STARTPOWERSHELL
+    MENUITEM    "Uruchom &Explorer...\tCtrl+E",   IDM_STARTEXPLORER
+    END
     MENUITEM    "Skocz do kata&logu...\tCtrl+G",  IDM_GOTODIR
     MENUITEM    SEPARATOR
     MENUITEM    "Za&kończ",                       IDM_EXIT

--- a/src/lang/res_tr-TR.rc
+++ b/src/lang/res_tr-TR.rc
@@ -36,10 +36,13 @@ BEGIN
         MENUITEM    "Dizi&n Oluştur...\tCtrl+Shift+N", IDM_MAKEDIR
         MENUITEM    "A&ra...\tCtrl+F",              IDM_SEARCH
         MENUITEM    "Dosyaları Se&ç...",            IDM_SELECT
-        MENUITEM    "Bash Kabuğu &Başlat...\tCtrl+B",  IDM_STARTBASHSHELL
-        MENUITEM    "Cmd Kabuğu Ba&şlat...\tCtrl+K",   IDM_STARTCMDSHELL
-        MENUITEM    "Po&wershell'i Başlat...\tCtrl+P", IDM_STARTPOWERSHELL
-        MENUITEM    "E&xplorer'i Başlat...\tCtrl+E", IDM_STARTEXPLORER
+        POPUP       "Başlat (&.)"
+        BEGIN
+            MENUITEM    "&Bash Kabuğu Başlat...\tCtrl+B", IDM_STARTBASHSHELL
+            MENUITEM    "&Cmd Kabuğu Başlat...\tCtrl+K", IDM_STARTCMDSHELL
+            MENUITEM    "&Powershell'i Başlat...\tCtrl+P", IDM_STARTPOWERSHELL
+            MENUITEM    "&Explorer'i Başlat...\tCtrl+E", IDM_STARTEXPLORER
+        END
         MENUITEM    "Dizine &Git...",               IDM_GOTODIR
         MENUITEM    SEPARATOR
         MENUITEM    "Çı&kış",                       IDM_EXIT

--- a/src/lang/res_zh-CN.rc
+++ b/src/lang/res_zh-CN.rc
@@ -36,10 +36,13 @@ BEGIN
     MENUITEM    "创建目录(&E)...\tCtrl+Shift+N", IDM_MAKEDIR
     MENUITEM    "搜索(&H)...\tCtrl+F",       IDM_SEARCH
     MENUITEM    "选择文件(&F)...", IDM_SELECT
-    MENUITEM    "打开 Bash...\tCtrl+B", IDM_STARTBASHSHELL
-    MENUITEM    "打开命令提示符(&L)...\tCtrl+K", IDM_STARTCMDSHELL
-    MENUITEM    "打开 PowerShell(&W)...\tCtrl+P", IDM_STARTPOWERSHELL
-    MENUITEM    "打开 Explorer(&X)...\tCtrl+E", IDM_STARTEXPLORER
+    POPUP       "打开 (&.)"
+    BEGIN
+    MENUITEM    "打开 &Bash...\tCtrl+B", IDM_STARTBASHSHELL
+    MENUITEM    "打开命令提示符(&C)...\tCtrl+K", IDM_STARTCMDSHELL
+    MENUITEM    "打开 &PowerShell...\tCtrl+P", IDM_STARTPOWERSHELL
+    MENUITEM    "打开 &Explorer...\tCtrl+E", IDM_STARTEXPLORER
+    END
     MENUITEM    "转到目录(&G)...\tCtrl+G", IDM_GOTODIR
     MENUITEM    SEPARATOR
     MENUITEM    "退出(&X)",            IDM_EXIT


### PR DESCRIPTION
This is after encountering that `Alt+F`, `X` no longer exits, because `X` is double-assigned between "Open With Explorer" and "Exit."  In `en-US`, `Alt+F`, `X` is a very established UI pattern for pull down menu based applications.

In the File menu, there were 24 items allocating letters for shortcuts, out of a 26 character alphabet, so there's really no more room to move in terms of assigning letters.

This change moves four items into a submenu, which frees up some letters for allocation and allows those items to have hotkeys that more naturally maps to their function.  It uses `Alt+F`, `.` to access the submenu, which I'm not happy about, but this results from the same issue it's trying to fix (the menu is so large that natural hotkeys can't be allocated.)  In English, none of the letters of "Start" were available, so the submenu hotkey was always going to be a little contrived.  Using `Alt+F`, `.` seems to work well on a keyboard and can also be consistent across languages.