### PR TITLE
Use IDS_KK_ strings in zh-CN.

### DIFF
--- a/src/lang/res_zh-CN.rc
+++ b/src/lang/res_zh-CN.rc
@@ -255,13 +255,13 @@ BEGIN
     IDS_HARDLINK,           "硬链接"                      /* 32 */
 
     IDS_KK_COPYFROMSTR,     "从(&F):"
-    IDS_KK_COPYTOSTR,       "到(&T):"
-    IDS_KK_RENAMEFROMSTR,   "从(&F):"
-    IDS_KK_RENAMETOSTR,     "到(&T):"
+    IDS_KK_COPYTOSTR,       "复制到(&T):"
+    IDS_KK_RENAMEFROMSTR,   "原名(&F):"
+    IDS_KK_RENAMETOSTR,     "重命名为(&T):"
     IDS_KK_HARDLINKFROMSTR, "从(&F):"
-    IDS_KK_HARDLINKTOSTR,   "到(&T):"
+    IDS_KK_HARDLINKTOSTR,   "硬链接到(&T):"
     IDS_KK_SYMLINKFROMSTR,  "从(&F):"
-    IDS_KK_SYMLINKTOSTR,    "到(&T):"
+    IDS_KK_SYMLINKTOSTR,    "符号链接到(&T):"
 
     IDS_CREATINGMSG,        "创建:"                     /* 32 */
     IDS_REMOVINGDIRMSG,     "正在删除:"                     /* 32 */

--- a/src/lang/winfile_zh-CN.dlg
+++ b/src/lang/winfile_zh-CN.dlg
@@ -291,8 +291,8 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     CONTROL         "当前目录: N", IDD_DIR, "Static", SS_SIMPLE | SS_NOPREFIX, 3, 6, 232, 10
 
-    CONTROL         "到(&T):", IDD_KK_TEXTTO, "Static", SS_LEFTNOWORDWRAP, 3, 33, 20, 10
-    EDITTEXT        IDD_TO, 37, 32, 188, 12, ES_AUTOHSCROLL
+    CONTROL         "移动到(&T):", IDD_KK_TEXTTO, "Static", SS_LEFTNOWORDWRAP, 3, 33, 50, 10
+    EDITTEXT        IDD_TO, 62, 32, 163, 12, ES_AUTOHSCROLL
 
     CONTROL         "", IDD_STATUS, "Static", SS_SIMPLE | SS_NOPREFIX, 3, 49, 40, 10
     CONTROL         "", IDD_NAME, "Static", SS_SIMPLE | SS_NOPREFIX,  45, 49, 190, 10
@@ -302,8 +302,8 @@ BEGIN
     PUSHBUTTON      "取消", IDCANCEL, 235, 23, 40, 14
     PUSHBUTTON      "帮助(&H)", IDD_HELP, 235, 40, 40, 14
 
-    CONTROL         "从(&F):", IDD_KK_TEXTFROM, "Static", SS_LEFTNOWORDWRAP, 3, 19, 20, 10
-    EDITTEXT        IDD_FROM, 37, 18, 188, 12, ES_AUTOHSCROLL
+    CONTROL         "从(&F):", IDD_KK_TEXTFROM, "Static", SS_LEFTNOWORDWRAP, 3, 19, 50, 10
+    EDITTEXT        IDD_FROM, 62, 18, 163, 12, ES_AUTOHSCROLL
 
     CONTROL         "", IDD_DIRS, "Static", SS_LEFTNOWORDWRAP, 3, 49, 230, 10
 END


### PR DESCRIPTION
Try to make strings friendly to readers.
This is an example to demonstrate the use of mechanisms provided by #388. This is a rough, personal opinion, based on previous practice of ja-JP.

- `IDS_KK_RENAMEFROMSTR` and `IDS_KK_RENAMETOSTR` is translated like ja-JP (Original name / Rename to), instead of single `From` in English.
- Verbs are added in all other `IDS_KK_*TOSTR`.
- Dialog controls are resized to fit.