### PR TITLE
Make 'Other:' text in MOVECOPY dialog localizable

### DIFF
--- a/src/lang/res_de-DE.rc
+++ b/src/lang/res_de-DE.rc
@@ -246,6 +246,7 @@ BEGIN
     IDS_PRINTONLYONE        "Datei-Manager kann nicht mehrere Dateien drucken.\n\nWählen Sie eine Datei aus und versuchen Sie es erneut."                                               /* 128 */
 
     IDS_CURDIRIS,           "Aktuelles Verzeichnis: %s"                                                                                                    /* 128 */
+    IDS_CURDIRSARE,         "Other: "
     IDS_COPY,               "Kopieren"                          /* 32 */
     IDS_RENAME,             "Umbenennen"                        /* 32 */
     IDS_FORMAT,             "Datenträger formatieren"                   /* 32 */

--- a/src/lang/res_en-US.rc
+++ b/src/lang/res_en-US.rc
@@ -248,6 +248,7 @@ BEGIN
     IDS_PRINTONLYONE        "File Manager cannot print multiple files.\n\nSelect only one file, and then try again."                                               /* 128 */
 
     IDS_CURDIRIS,           "Current Directory: %s"                                                                                                    /* 128 */
+    IDS_CURDIRSARE,         "Other current directories: "
     IDS_COPY,               "Copy"                          /* 32 */
     IDS_RENAME,             "Rename"                        /* 32 */
     IDS_FORMAT,             "Format Disk"                   /* 32 */

--- a/src/lang/res_he-IL.rc
+++ b/src/lang/res_he-IL.rc
@@ -248,6 +248,7 @@ BEGIN
     IDS_PRINTONLYONE        "מנהל הקבצים אינו יכול להדפיס קבצים מרובים.\n\nבחר קובץ אחד בלבד ונסה שוב."                             /* 128 */
 
     IDS_CURDIRIS,           "תיקיה נוכחית: %s"                                                                                       /* 128 */
+    IDS_CURDIRSARE,         "Other: "
     IDS_COPY,               "העתקה"                                                                                                  /* 32 */
     IDS_RENAME,             "שינוי שם"                                                                                               /* 32 */
     IDS_FORMAT,             "אתחול דיסק/תקליטון"                                                                                     /* 32 */

--- a/src/lang/res_ja-JP.rc
+++ b/src/lang/res_ja-JP.rc
@@ -248,6 +248,7 @@ BEGIN
     IDS_PRINTONLYONE        "ファイル マネージャーは同時に複数のファイルを印刷する事はできません。\n\nファイルを1つだけ選択しもう一度試して下さい。"                                               /* 128 */
 
     IDS_CURDIRIS,           "現在のディレクトリ: %s"                                                                                                    /* 128 */
+    IDS_CURDIRSARE,         "Other: "
     IDS_COPY,               "コピー"                          /* 32 */
     IDS_RENAME,             "名前を変更"                        /* 32 */
     IDS_FORMAT,             "ディスクのフォーマット"                   /* 32 */

--- a/src/lang/res_pl-PL.rc
+++ b/src/lang/res_pl-PL.rc
@@ -248,6 +248,7 @@ BEGIN
     IDS_PRINTONLYONE        "Menedżer plików nie może drukować wielu plików.\n\nWybierz tylko jeden plik i spróbuj ponownie."                                               /* 128 */
 
     IDS_CURDIRIS,           "Bieżący katalog: %s"                                                                                                    /* 128 */
+    IDS_CURDIRSARE,         "Other: "
     IDS_COPY,               "Kopiuj"                          /* 32 */
     IDS_RENAME,             "Zmień nazwę"                     /* 32 */
     IDS_FORMAT,             "Formatuj dysk"                   /* 32 */

--- a/src/lang/res_tr-TR.rc
+++ b/src/lang/res_tr-TR.rc
@@ -247,6 +247,7 @@ BEGIN
    IDS_PRINTONLYONE         "Birden fazla dosya yazdırılamıyor.\n\nTek bir dosya seçip yeniden deneyin."
 
    IDS_CURDIRIS,            "Geçerli Dizin: %s"
+   IDS_CURDIRSARE,          "Other: "
    IDS_COPY,                "Kopyala"
    IDS_RENAME,              "Ad Değiştir"
    IDS_FORMAT,              "Disk Biçimlendir"

--- a/src/lang/res_zh-CN.rc
+++ b/src/lang/res_zh-CN.rc
@@ -247,6 +247,7 @@ BEGIN
     IDS_PRINTONLYONE        "文件管理器不能同时打印多份文件。\n\n只选择一份文件，然后重试。"                                               /* 128 */
 
     IDS_CURDIRIS,           "当前目录: %s"                                                                                                    /* 128 */
+    IDS_CURDIRSARE,         "Other: "
     IDS_COPY,               "复制"                          /* 32 */
     IDS_RENAME,             "重命名"                        /* 32 */
     IDS_FORMAT,             "格式化磁盘"                   /* 32 */

--- a/src/res.h
+++ b/src/res.h
@@ -331,7 +331,8 @@
 #define IDS_FORMATSELDISK   146
 #define IDS_SYMLINK         147
 #define IDS_HARDLINK        148
-//#define IDS_DISCONSELDISK   149
+#define IDS_CURDIRSARE      149
+//#define IDS_DISCONSELDISK   149 reused
 #define IDS_CREATINGMSG     150
 #define IDS_REMOVINGMSG     151
 #define IDS_COPYINGMSG      152

--- a/src/wfdlgs2.c
+++ b/src/wfdlgs2.c
@@ -544,7 +544,7 @@ JAPANEND
 
             driveCur = (int)GetWindowLongPtr(hwndActive, GWL_TYPE);
 
-            lstrcpy(szDirs, TEXT("Other: "));
+            LoadString(hAppInstance, IDS_CURDIRSARE, szDirs, COUNTOF(szDirs));
 
             GetAllDirectories(rgszDirs);
 


### PR DESCRIPTION
Continuing from #400 .  This is a crude change to make the `Other:` text localizable.  For `en-US` I changed it to be a bit more descriptive, which is built on the assumption that the dialog will be large enough to accommodate it.

Note the current directory at the top of the dialog has some nice logic in `SetDlgDirectory` to truncate from the middle if it doesn't fit.  It would be really nice to do something similar here, but this text can contain an arbitrary number of components.  Also note that the current dialog resource specifies this text to be on a single line only, presumably because splitting lines based on spaces in paths wouldn't create a "natural" flow for paths.

I'm tempted to make the dialog resource multi-line, use one line per drive here, and use the logic in `SetDlgDirectory` to truncate these intelligently if they don't fit.  That's based on the observation that this dialog is wide and not high, so it has room to be larger vertically.