### PR TITLE
Refresh tree on junction or directory symlink creation

### DIFF
--- a/src/lfn.c
+++ b/src/lfn.c
@@ -737,6 +737,7 @@ DWORD WFJunction(LPCWSTR pszLinkDirectory, LPCWSTR pszLinkTarget)
    }
 
    CloseHandle(hFile);
+   ChangeFileSystem(FSC_MKDIR, pszLinkDirectory, NULL);
    return ERROR_SUCCESS;
 }
 

--- a/src/lfn.c
+++ b/src/lfn.c
@@ -585,7 +585,7 @@ WFSymbolicLink(LPTSTR pszFrom, LPTSTR pszTo, DWORD dwFlags)
    Notify(hdlgProgress, IDS_COPYINGMSG, pszFrom, pszTo);
 
    if (CreateSymbolicLink(pszTo, pszFrom, dwFlags | (bDeveloperModeAvailable ? SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE : 0))) {
-      ChangeFileSystem(FSC_CREATE, pszTo, NULL);
+      ChangeFileSystem(dwFlags == SYMBOLIC_LINK_FLAG_DIRECTORY ? FSC_MKDIR : FSC_CREATE, pszTo, NULL);
       dwRet = ERROR_SUCCESS;
    } else {
       dwRet = GetLastError();

--- a/src/treectl.c
+++ b/src/treectl.c
@@ -509,14 +509,26 @@ InsertDirectory(
        pNode->dwAttribs = dwAttribs;
    }
 
-   SendMessage(hwndLB, LB_INSERTSTRING, iMax, (LPARAM)pNode);
+   BOOL bInsertNode = TRUE;
+   if (pNode->dwAttribs & ATTR_JUNCTION)
+      if (!(GetWindowLongPtr(GetParent(hwndTreeCtl), GWL_ATTRIBS) & ATTR_JUNCTION))
+         bInsertNode = FALSE;
 
-   if (ppNode)
+   if (bInsertNode)
    {
-      *ppNode = pNode;
-   }
+      SendMessage(hwndLB, LB_INSERTSTRING, iMax, (LPARAM)pNode);
 
-   return (iMax);
+      if (ppNode)
+      {
+         *ppNode = pNode;
+      }
+      return iMax;
+   }
+   else 
+   {
+      LocalFree(pNode);
+      return 0;
+   }
 }
 
 
@@ -1188,7 +1200,7 @@ FillTreeListbox(HWND hwndTC,
                                &pNode,
                                IsCasePreservedDrive(DRIVEID(szDefaultDir)),
                                bPartialSort,
-                               (DWORD)(-1) );
+                               INVALID_FILE_ATTRIBUTES );
 
       if (pNode) {
 
@@ -2101,7 +2113,6 @@ TreeControlWndProc(
    INT    iSel;
    INT    i, j;
    INT    nIndex;
-   DWORD  dwTemp;
    PDNODE pNode, pNodeNext;
    HWND  hwndLB;
    HWND  hwndParent;
@@ -2466,14 +2477,14 @@ TreeControlWndProc(
          //
          // Insert it into the tree listbox
          //
-         dwTemp = InsertDirectory( hwnd,
-                                   pNode,
-                                   (WORD)nIndex,
-                                   szPath,
-                                   &pNodeT,
-                                   IsCasePreservedDrive(DRIVEID(((LPTSTR)lParam))),
-                                   FALSE,
-                                   (DWORD)(-1) );
+         InsertDirectory( hwnd,
+                          pNode,
+                          (WORD)nIndex,
+                          szPath,
+                          &pNodeT,
+                          IsCasePreservedDrive(DRIVEID(((LPTSTR)lParam))),
+                          FALSE,
+                          INVALID_FILE_ATTRIBUTES );
 
          //
          // Add a plus if necessary

--- a/src/treectl.c
+++ b/src/treectl.c
@@ -2487,7 +2487,7 @@ TreeControlWndProc(
          bUpdateTree = TRUE;
          if (dwFSCOperation == FSC_JUNCTION) {
             DWORD dwAttribsToInclude;
-            dwAttribsToInclude = GetWindowLongPtr(GetParent(hwnd), GWL_ATTRIBS);
+            dwAttribsToInclude = (DWORD)GetWindowLongPtr(GetParent(hwnd), GWL_ATTRIBS);
             if ((dwAttribsToInclude & ATTR_JUNCTION) == 0) {
                bUpdateTree = FALSE;
             }

--- a/src/treectl.c
+++ b/src/treectl.c
@@ -192,8 +192,7 @@ SetNodeAttribs(PDNODE pNode, LPTSTR szPath)
    //
    if (pNode->dwAttribs & ATTR_REPARSE_POINT) {
 
-      TCHAR szTemp[MAXPATHLEN];
-      int tag = DecodeReparsePoint(szPath, szTemp, MAXPATHLEN);
+      DWORD tag = DecodeReparsePoint(szPath, NULL, 0);
       switch (tag) {
       case IO_REPARSE_TAG_MOUNT_POINT:
          pNode->dwAttribs |= ATTR_JUNCTION;
@@ -509,26 +508,13 @@ InsertDirectory(
        pNode->dwAttribs = dwAttribs;
    }
 
-   BOOL bInsertNode = TRUE;
-   if (pNode->dwAttribs & ATTR_JUNCTION)
-      if (!(GetWindowLongPtr(GetParent(hwndTreeCtl), GWL_ATTRIBS) & ATTR_JUNCTION))
-         bInsertNode = FALSE;
+   SendMessage(hwndLB, LB_INSERTSTRING, iMax, (LPARAM)pNode);
 
-   if (bInsertNode)
+   if (ppNode)
    {
-      SendMessage(hwndLB, LB_INSERTSTRING, iMax, (LPARAM)pNode);
-
-      if (ppNode)
-      {
-         *ppNode = pNode;
-      }
-      return iMax;
+      *ppNode = pNode;
    }
-   else 
-   {
-      LocalFree(pNode);
-      return 0;
-   }
+   return iMax;
 }
 
 
@@ -2441,22 +2427,41 @@ TreeControlWndProc(
    {
       PDNODE pNodePrev;
       PDNODE pNodeT;
+      DWORD  dwFSCOperation;
+      BOOLEAN bCreationOperation;
+      BOOLEAN bUpdateTree;
 
-      if (!lParam || wParam == FSC_REFRESH)
+      dwFSCOperation = FSC_Operation(wParam);
+      bDirectoryOperation = FALSE;
+
+      if (!lParam || dwFSCOperation == FSC_REFRESH) {
          break;
+      }
 
-      /* Did we find it? */
+      if (dwFSCOperation == FSC_MKDIR ||
+          dwFSCOperation == FSC_JUNCTION ||
+          dwFSCOperation == FSC_SYMLINKD) {
+
+         bCreationOperation = TRUE;
+      }
+
+      //
+      // search for a tree node corresponding to the item (if it is being
+      // removed), or to the item's parent (if it is being added.)  If an
+      // item is not found, there is no further processing to perform.
+      //
       if (!FindItemFromPath(hwndLB, (LPTSTR)lParam,
-          wParam == FSC_MKDIR || wParam == FSC_MKDIRQUIET, (DWORD*)&nIndex, &pNode)) {
+          bCreationOperation, (DWORD*)&nIndex, &pNode)) {
          break;
       }
 
       lstrcpy(szPath, (LPTSTR)lParam);
       StripPath(szPath);
 
-      switch (wParam) {
+      switch (dwFSCOperation) {
       case FSC_MKDIR:
-      case FSC_MKDIRQUIET:
+      case FSC_JUNCTION:
+      case FSC_SYMLINKD:
 
          //
          // auto expand the branch so they can see the new
@@ -2464,50 +2469,66 @@ TreeControlWndProc(
          //
          if (!(pNode->wFlags & TF_EXPANDED) &&
             (nIndex == (INT)SendMessage(hwndLB, LB_GETCURSEL, 0, 0L)) &&
-            FSC_MKDIRQUIET != wParam)
+            ((wParam & FSC_QUIET) == 0)) {
 
             SendMessage(hwnd, TC_EXPANDLEVEL, FALSE, 0L);
+         }
 
          //
          // make sure this node isn't already here
          //
-         if (FindItemFromPath(hwndLB, (LPTSTR)lParam, FALSE, NULL, NULL))
+         if (FindItemFromPath(hwndLB, (LPTSTR)lParam, FALSE, NULL, NULL)) {
             break;
+         }
 
          //
-         // Insert it into the tree listbox
+         // If FSC_JUNCTION, check if junctions should be displayed
          //
-         InsertDirectory( hwnd,
-                          pNode,
-                          (WORD)nIndex,
-                          szPath,
-                          &pNodeT,
-                          IsCasePreservedDrive(DRIVEID(((LPTSTR)lParam))),
-                          FALSE,
-                          INVALID_FILE_ATTRIBUTES );
+         bUpdateTree = TRUE;
+         if (dwFSCOperation == FSC_JUNCTION) {
+            DWORD dwAttribsToInclude;
+            dwAttribsToInclude = GetWindowLongPtr(GetParent(hwnd), GWL_ATTRIBS);
+            if ((dwAttribsToInclude & ATTR_JUNCTION) == 0) {
+               bUpdateTree = FALSE;
+            }
+         }
 
-         //
-         // Add a plus if necessary
-         //
-         if (GetWindowLongPtr(hwndParent, GWL_VIEW) & VIEW_PLUSES) {
-
-            lstrcpy(szPath, (LPTSTR)lParam);
-            ScanDirLevel( (PDNODE)pNodeT,
-                          szPath,
-                          (GetWindowLongPtr(hwndParent, GWL_ATTRIBS) & (ATTR_HS | ATTR_JUNCTION)));
+         if (bUpdateTree) {
 
             //
-            // Invalidate the window so the plus gets drawn if needed
+            // Insert it into the tree listbox
             //
-            if (((PDNODE)pNodeT)->wFlags & TF_HASCHILDREN) {
-               InvalidateRect(hwndLB, NULL, FALSE);
+            InsertDirectory( hwnd,
+                             pNode,
+                             (WORD)nIndex,
+                             szPath,
+                             &pNodeT,
+                             IsCasePreservedDrive(DRIVEID(((LPTSTR)lParam))),
+                             FALSE,
+                             INVALID_FILE_ATTRIBUTES );
+
+            //
+            // Add a plus if necessary
+            //
+            if (GetWindowLongPtr(hwndParent, GWL_VIEW) & VIEW_PLUSES) {
+
+               lstrcpy(szPath, (LPTSTR)lParam);
+               ScanDirLevel( (PDNODE)pNodeT,
+                             szPath,
+                             (GetWindowLongPtr(hwndParent, GWL_ATTRIBS) & (ATTR_HS | ATTR_JUNCTION)));
+
+               //
+               // Invalidate the window so the plus gets drawn if needed
+               //
+               if (((PDNODE)pNodeT)->wFlags & TF_HASCHILDREN) {
+                  InvalidateRect(hwndLB, NULL, FALSE);
+               }
             }
          }
 
          break;
 
       case FSC_RMDIR:
-      case FSC_RMDIRQUIET:
 
          //
          // Don't do anything while the tree is being built.
@@ -2575,7 +2596,7 @@ TreeControlWndProc(
                // In the quiet case, don't change selection.
                // FSC_RENAME will handle this for us.
                //
-               if (FSC_RMDIRQUIET != wParam) {
+               if ((wParam & FSC_QUIET) == 0) {
                   SendMessage(hwndLB, LB_SETCURSEL, nIndex - 1, 0L);
                   SendMessage(hwnd, WM_COMMAND, GET_WM_COMMAND_MPS(0, hwndLB, LBN_SELCHANGE));
                }

--- a/src/treectl.c
+++ b/src/treectl.c
@@ -2432,7 +2432,7 @@ TreeControlWndProc(
       BOOLEAN bUpdateTree;
 
       dwFSCOperation = FSC_Operation(wParam);
-      bDirectoryOperation = FALSE;
+      bCreationOperation = FALSE;
 
       if (!lParam || dwFSCOperation == FSC_REFRESH) {
          break;

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -257,6 +257,7 @@ ChangeFileSystem(
    TCHAR  szTo[MAXPATHLEN];
    TCHAR  szTemp[MAXPATHLEN];
    TCHAR  szPath[MAXPATHLEN + MAXPATHLEN];
+   DWORD  dwFSCOperation;
 
    // As FSC messages come in from outside winfile
    // we set a timer, and when that expires we
@@ -286,10 +287,15 @@ ChangeFileSystem(
    lstrcpy(szFrom, lpszFile);
    QualifyPath(szFrom);            // already partly qualified
 
-   switch (dwFunction)
+   dwFSCOperation = FSC_Operation(dwFunction);
+
+   switch (dwFSCOperation)
    {
       case ( FSC_RENAME ) :
       {
+         DWORD dwAttribs;
+         DWORD dwFSCOperation;
+
          lstrcpy(szTo, lpszTo);
          QualifyPath(szTo);    // already partly qualified
 
@@ -308,15 +314,32 @@ ChangeFileSystem(
          // Are we renaming a directory?
          lstrcpy(szTemp, szTo);
 
-         if (GetFileAttributes(szTemp) & ATTR_DIR)
+         dwAttribs = GetFileAttributes(szTemp);
+
+         if (dwAttribs & ATTR_DIR)
          {
+            dwFSCOperation = FSC_MKDIR;
+
+            // Check if the directory is a junction or symbolic link.  These
+            // have unique operation codes to keep optional junction display
+            // straightforward.
+            if (dwAttribs & ATTR_REPARSE_POINT)
+            {
+               DWORD dwReparseTag;
+               dwReparseTag = DecodeReparsePoint(szTemp, NULL, 0);
+               if (dwReparseTag == IO_REPARSE_TAG_MOUNT_POINT) {
+                   dwFSCOperation = FSC_JUNCTION;
+               } else if (dwReparseTag == IO_REPARSE_TAG_SYMLINK) {
+                   dwFSCOperation = FSC_SYMLINKD;
+               }
+            }
             for (hwnd = GetWindow(hwndMDIClient, GW_CHILD);
                  hwnd;
                  hwnd = GetWindow(hwnd, GW_HWNDNEXT))
             {
                if (hwndTree = HasTreeWindow(hwnd))
                {
-                  SendMessage(hwndTree, WM_FSC, FSC_RMDIRQUIET, (LPARAM)szFrom);
+                  SendMessage(hwndTree, WM_FSC, FSC_RMDIR | FSC_QUIET, (LPARAM)szFrom);
 
                   // if the current selection is szFrom, we update the
                   // selection after the rename occurs
@@ -324,7 +347,7 @@ ChangeFileSystem(
                   SendMessage(hwnd, FS_GETDIRECTORY, COUNTOF(szPath), (LPARAM)szPath);
                   StripBackslash(szPath);
 
-                  SendMessage(hwndTree, WM_FSC, FSC_MKDIRQUIET, (LPARAM)szTo);
+                  SendMessage(hwndTree, WM_FSC, dwFSCOperation | FSC_QUIET, (LPARAM)szTo);
 
                   // update the selection if necessary, also
                   // change the window text in this case to
@@ -355,7 +378,8 @@ ChangeFileSystem(
       }
 
       case ( FSC_MKDIR ) :
-      case ( FSC_MKDIRQUIET ) :
+      case ( FSC_JUNCTION ) :
+      case ( FSC_SYMLINKD ) :
       {
          /* Update the tree. */
          for (hwnd = GetWindow(hwndMDIClient, GW_CHILD);

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -249,8 +249,8 @@ UpdateAllDirWindows(
 VOID
 ChangeFileSystem(
    DWORD dwFunction,
-   LPTSTR lpszFile,
-   LPTSTR lpszTo)
+   LPCTSTR lpszFile,
+   LPCTSTR lpszTo)
 {
    HWND   hwnd, hwndTree, hwndOld;
    TCHAR  szFrom[MAXPATHLEN];

--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -2813,14 +2813,6 @@ SkipMKDir:
             break;
          }
 
-
-         if (ERROR_SUCCESS == ret)
-            //
-            // set attributes of dest to source (not including the
-            // subdir and vollabel bits)
-            //
-            WFSetAttr(szDest, pDTA->fd.dwFileAttributes & ~(ATTR_DIR | ATTR_VOLUME));
-
          //
          // If symlink dir already exists ignore the error. return
          // as long as it is a directory and not a file.

--- a/src/wffile.c
+++ b/src/wffile.c
@@ -128,8 +128,9 @@ DWORD MKDir(
       dwErr = GetLastError();
 
       // CreateDirectoryEx does not support developer mode, so create symbolic ourselves
-      if (ERROR_PRIVILEGE_NOT_HELD == dwErr)
-         dwErr = WFCopyIfSymlink(pSrc, pName, SYMBOLIC_LINK_FLAG_DIRECTORY, FSC_MKDIR);
+      if (ERROR_PRIVILEGE_NOT_HELD == dwErr) {
+         dwErr = WFCopyIfSymlink(pSrc, pName, SYMBOLIC_LINK_FLAG_DIRECTORY, FSC_SYMLINKD);
+      }
    }
 
    return dwErr;

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -362,7 +362,7 @@ VOID vWaitMessage();
 
 VOID RedoDriveWindows(HWND);
 BOOL FmifsLoaded(VOID);
-VOID  ChangeFileSystem(DWORD dwOper, LPWSTR lpPath, LPWSTR lpTo);
+VOID  ChangeFileSystem(DWORD dwOper, LPCTSTR lpPath, LPCTSTR lpTo);
 HWND  CreateDirWindow(LPWSTR szPath, BOOL bReplaceOpen, HWND hwndActive);
 HWND CreateTreeWindow(LPWSTR szPath, INT x, INT y, INT dx, INT dy, INT dxSplit);
 VOID SwitchToSafeDrive();

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -749,17 +749,23 @@ BOOL  RectTreeItem(HWND hwndLB, INT iItem, BOOL bFocusOn);
 #define TYPE_SEARCH         -1
 
 /* WM_FILESYSCHANGE (WM_FSC) message wParam value */
-#define FSC_CREATE          0
-#define FSC_DELETE          1
-#define FSC_RENAME          2
-#define FSC_ATTRIBUTES      3
-#define FSC_NETCONNECT      4
-#define FSC_NETDISCONNECT   5
-#define FSC_REFRESH         6
-#define FSC_MKDIR           7
-#define FSC_RMDIR           8
-#define FSC_RMDIRQUIET      9
-#define FSC_MKDIRQUIET      10
+#define FSC_CREATE          0x0000
+#define FSC_DELETE          0x0001
+#define FSC_RENAME          0x0002
+#define FSC_ATTRIBUTES      0x0003
+#define FSC_NETCONNECT      0x0004
+#define FSC_NETDISCONNECT   0x0005
+#define FSC_REFRESH         0x0006
+#define FSC_MKDIR           0x0007
+#define FSC_RMDIR           0x0008
+#define FSC_JUNCTION        0x0009
+#define FSC_SYMLINKD        0x000A
+
+#define FSC_QUIET           0x8000
+#define FSC_OPERATIONMASK   0x00ff
+
+#define FSC_Operation(FSC)  \
+    ((FSC) & FSC_OPERATIONMASK)
 
 #define WM_LBTRACKPT        0x131
 


### PR DESCRIPTION
This PR aims to build upon schinagl's earlier work in #409 and #406 .

In those discussions, the remaining issue was a case where links could be created as hidden, which would cause the left pane to be updated to contain the link (when it should be hidden.)

To summarize, three options were discussed to address it:
1. Avoid creating junctions/symlinks as hidden.
2. If they need to be created as hidden, do this before updating the UI, then have the UI check file attributes and decide what to include.
3. Leave the attribute update where it is today, and have the attribute update also update the UI, meaning that new links would be inserted and then removed when they become hidden.

This PR takes the first approach, because the behavior of Winfile here seems inconsistent with mklink and was unexpected to me.  The original file attribute change seemed undesirable, and it triggered later problems for refreshing the tree, so this solves two problems in one.

We still need to ensure junctions aren't included in the left pane if the user is hiding junctions.  This PR moves that logic up and out of `InsertDirectory`, mainly because a previous attempt to add hidden/system handling there showed it would become tricky since callers treat `InsertDirectory` as a command (and expect a tree node returned.)

Rather than have the FSC handler code inspect file attributes, this PR instead indicates the operation explicitly (mkdir, junction, or directory symlink.)  The FSC handler code can be simplified by only applying junction hiding to junction creation.  Currently directory creation and directory symlinks are handled identically, so splitting these out was for consistency with junctions.

Previously directory creation had a "quiet" variant, which meant "don't expand the tree."  Since this applies to the others too, this PR makes it a flag that can be combined with other operations.

## Next steps

While looking into these, a few longstanding issues came to light:

1. The behavior of creating a junction or directory symbolic link as hidden seems to have originated from copy, where link creation followed copy behavior.  The same issue exists with directory copy, where copying a hidden directory will first update the tree view, then update file attributes to mark the new directory as hidden, but leave the hidden directory in the tree.  This behavior is longstanding (it exists in the 16 bit versions of Winfile), and unlike here, there's a clear rationale for a copied directory to apply the file attributes of the source.
2. When file attributes are changed on a directory, marking it hidden/system, the left pane is not updated.  This seems to be longstanding behavior.  Although this PR doesn't address it, as of this writing, it looks simple to address: the `FSC_RENAME` handler already inspects file attributes to check if an object is a directory, and based on that, perform left pane updates.  Here, we'd want something similar, where if hidden/system files are being hidden and an attribute change occurs on a directory, the operation should either take the current `FSC_MKDIR` or `FSC_RMDIR` logic as appropriate.  This might be sufficient to address the case above.
3. An explicit refresh through the Window menu does not refresh the left pane.  This appears to be caused by changes in 10.0 in the `TC_SETDRIVE` handler where if a node is found it is selected without generating a full refresh.  I'm not familiar with the history of these changes, so this will require a little more investigation to see what can be done.