### PR TITLE
Make the refresh menu item refresh the left pane

### DIFF
--- a/src/wfutil.c
+++ b/src/wfutil.c
@@ -317,8 +317,6 @@ RefreshWindow(
    BOOL bFlushCache)
 {
    HWND hwndTree, hwndDir;
-   LPARAM lParam;
-   TCHAR szDir[MAXPATHLEN];
    DRIVE drive;
 
    //
@@ -334,38 +332,32 @@ RefreshWindow(
    //
    drive = (DRIVE)GetWindowLongPtr(hwndActive, GWL_TYPE);
 
-   if ((drive >= 0) && !CheckDrive(hwndActive, drive, FUNC_SETDRIVE))
+   if ((drive >= 0) && !CheckDrive(hwndActive, drive, FUNC_SETDRIVE)) {
       return;
+   }
 
    //
    // If bFlushCache, remind ourselves to try it
    //
-   if (bFlushCache)
+   if (bFlushCache) {
       aDriveInfo[drive].bShareChkTried = FALSE;
+   }
 
    // NOTE: similar to CreateDirWindow
 
    //
    // update the dir part first so tree can steal later
    //
-   if (hwndDir = HasDirWindow(hwndActive))
+   if (hwndDir = HasDirWindow(hwndActive)) {
       SendMessage(hwndDir, FS_CHANGEDISPLAY, CD_PATH, 0L);
+   }
 
    if (hwndTree = HasTreeWindow(hwndActive)) {
-      //
-      // remember the current directory
-      //
-      SendMessage(hwndActive, FS_GETDIRECTORY, COUNTOF(szDir), (LPARAM)szDir);
 
       //
       // update the drives windows
       //
       SendMessage(hwndActive, FS_CHANGEDRIVES, 0, 0L);
-
-      if (IsValidDisk(DRIVEID(szDir)))
-         lParam = (LPARAM)szDir;
-      else
-         lParam = 0L;
 
       //
       // update the tree
@@ -373,11 +365,12 @@ RefreshWindow(
       SendMessage(hwndTree,
                   TC_SETDRIVE,
                   MAKELONG(MAKEWORD(FALSE,TRUE),TRUE),
-                  lParam);
+                  0L);
    }
 
-   if (hwndActive == hwndSearch)
+   if (hwndActive == hwndSearch) {
       SendMessage(hwndActive, FS_CHANGEDISPLAY, CD_PATH, 0L);
+   }
 }
 
 //


### PR DESCRIPTION
`TC_SETDRIVE` currently takes three boolean values encoded into `wParam` and an optional path in `lParam`.  If `lParam` is `NULL`, it looks up the directory from `FS_GETDIRECTORY`.

Between `original_plus` and the first 10.0 release, a change was made in `TC_SETDRIVE` that will update the selection without a refresh if the value supplied in `lParam` can be found in the existing tree.  In some cases, such as the View File Types dialog, `TC_SETDRIVE` is invoked with a `NULL` `lParam`, which causes a full refresh to occur.  In others, including `RefreshWindow`, `lParam` is supplied as a directory, which has the effect of suppressing any refresh.

This change modifies `RefreshWindow` to not supply `lParam` as a way to cause the refresh to happen.  The previous code was calling `FS_GETDIRECTORY` from `RefreshWindow`, then calling `FS_CHANGEDRIVES`, then calling `TC_SETDRIVE`. The code reads as though it expects `FS_CHANGEDRIVES` to invalidate the directory, so it must be saved first.  However, I do not see `FS_CHANGEDRIVES` doing this, and have looked back to the oldest source I can find in Windows 3.1 (where `FS_CHANGEDRIVES` is very different) but still don't see it doing this.  The "worst" case I can find or think of is if `FS_CHANGEDRIVES` decides that the drive owned by a window no longer exists, but in this case, the code was already setting `lParam` to `NULL`.  I've tested this case and even with this change the program seems to behave correctly (it displays an error to the user about the drive being invalid before and after this change.)

That said, there are other options for a fix:
 * Note that `RefreshWindow` is called in a handful of places, not just in response to the refresh menu item.  This change could be scoped to `IDM_REFRESH` by adding a new parameter to `RefreshWindow`.
 * Alternatively, `TC_SETDRIVE` could take a fourth boolean to suppress the optimization, so that `RefreshWindow` could still save and restore the directory, but tell `TC_SETDRIVE` to perform a real refresh.  (This was my initial idea before noticing how `lParam` is affecting this in other paths.)
