### PR TITLE
VerifyResources support for pop up menus

### DIFF
--- a/tools/VerifyResources/Resources.h
+++ b/tools/VerifyResources/Resources.h
@@ -74,6 +74,7 @@ typedef struct
 
 #define MAXMENUITEMS 100
 
+#define MFR_POPUP 0x10
 #define MFR_END 0x80
 
 // used for both normal and popup items

--- a/tools/VerifyResources/VerifyResources.cpp
+++ b/tools/VerifyResources/VerifyResources.cpp
@@ -477,7 +477,14 @@ VOID DecodeMenu(VOID *lpv, MENUDECODE *pmenu)
     while (*pwT != MFR_END)
     {
         pitem->flags = *pwT++;
-        pitem->id = *pwT++;
+        if ((pitem->flags & MFR_POPUP) == 0)
+        {
+            pitem->id = *pwT++;
+        }
+        else
+        {
+            pitem->id = 0;
+        }
 
         pitem->lpszMenu = (LPCTSTR)pwT;
         pwT += wcslen(pitem->lpszMenu) + 1;
@@ -529,10 +536,9 @@ VOID VerifyLangMenus(PROCRES *pprocres)
             wchar_t szLocale[25];
             MENUITEM *pitem = &rgmenu[j].rgitem[i];
 
-            LCIDToLocaleName(rglcidInUse[j], szLocale, COUNTOF(szLocale), 0);
-
             if (pitem->id != id)
             {
+                LCIDToLocaleName(rglcidInUse[j], szLocale, COUNTOF(szLocale), 0);
                 printf("Error: menu %ls for language %ls does not have the required item %d\n", rgmenu[ILOCALE_ENG].lpszTitle, szLocale, id);
                 break;
             }


### PR DESCRIPTION
Popup menu resources do not contain an ID.  The immediate next word after the flags is the first character of the string.  This causes all languages to fail to verify the "Start" menu because they're effectively comparing for the first string character and failing.

This isn't the first time to find this type of issue in VerifyResources; I wish the resource format was documented better.