### PR TITLE
Don't mark Winfile as Universal since it can only run on Desktop systems

### DIFF
--- a/Package/Package.appxmanifest
+++ b/Package/Package.appxmanifest
@@ -14,7 +14,6 @@
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.14393.0" MaxVersionTested="10.0.14393.0" />
   </Dependencies>
   <Resources>


### PR DESCRIPTION
This is to fix #292 .  WinFile is a Desktop app and shouldn't appear on non-Desktop devices that support Universal binaries.  I can't test how the store will really behave until it's uploaded, but the docs suggest listing only a Desktop family is the way to express this.