### PR TITLE
XP build based on v141_xp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
+[Xx][Pp][Dd]ebug/
+[Xx][Pp][Rr]elease/
+[Aa][Rr][Mm]64/
 x64/
 x86/
 bld/

--- a/.gitignore
+++ b/.gitignore
@@ -13,19 +13,11 @@
 *.userprefs
 
 # Build results
-[Dd]ebug/
-[Dd]ebugPublic/
-[Rr]elease/
-[Rr]eleases/
-[Xx][Pp][Dd]ebug/
-[Xx][Pp][Rr]elease/
 [Aa][Rr][Mm]64/
 x64/
 x86/
+[Ww]in32/
 bld/
-[Bb]in/
-[Oo]bj/
-[Ll]og/
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/build/Winfile.default.props
+++ b/build/Winfile.default.props
@@ -13,6 +13,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="XPDebug|Win32">
+      <Configuration>XPDebug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|ARM64">
       <Configuration>Release</Configuration>
       <Platform>ARM64</Platform>
@@ -25,23 +29,31 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="XPRelease|Win32">
+      <Configuration>XPRelease</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='XPDebug'">
     <UseDebugLibraries>true</UseDebugLibraries>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='XPRelease'">
     <UseDebugLibraries>false</UseDebugLibraries>
     <LinkIncremental>false</LinkIncremental>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Label="Configuration">
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='XPRelease' or '$(Configuration)'=='XPDebug'">
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <XPDeprecationWarning>false</XPDeprecationWarning>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='Debug'">
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
 </Project>

--- a/build/Winfile.default.props
+++ b/build/Winfile.default.props
@@ -13,8 +13,8 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="XPDebug|Win32">
-      <Configuration>XPDebug</Configuration>
+    <ProjectConfiguration Include="DebugXPStatic|Win32">
+      <Configuration>DebugXPStatic</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|ARM64">
@@ -29,8 +29,8 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="XPRelease|Win32">
-      <Configuration>XPRelease</Configuration>
+    <ProjectConfiguration Include="ReleaseXPStatic|Win32">
+      <Configuration>ReleaseXPStatic</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
   </ItemGroup>
@@ -39,17 +39,17 @@
     <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='XPDebug'">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='DebugXPStatic'">
     <UseDebugLibraries>true</UseDebugLibraries>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='XPRelease'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='ReleaseXPStatic'">
     <UseDebugLibraries>false</UseDebugLibraries>
     <LinkIncremental>false</LinkIncremental>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='XPRelease' or '$(Configuration)'=='XPDebug'">
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='ReleaseXPStatic' or '$(Configuration)'=='DebugXPStatic'">
     <PlatformToolset>v141_xp</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>

--- a/build/Winfile.props
+++ b/build/Winfile.props
@@ -11,19 +11,21 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='XPDebug'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='DebugXPStatic'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(Configuration)'=='DebugXPStatic'">MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='XPRelease'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='ReleaseXPStatic'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
+      <RuntimeLibrary Condition="'$(Configuration)'=='Release'">MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(Configuration)'=='ReleaseXPStatic'">MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <OptimizeReferences>true</OptimizeReferences>
@@ -54,11 +56,7 @@
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
   </ItemDefinitionGroup>
-  <PropertyGroup Condition="'$(Platform)'=='Win32'">
-    <OutDir>$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Platform)'!='Win32'">
+  <PropertyGroup>
     <OutDir>$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>

--- a/build/Winfile.props
+++ b/build/Winfile.props
@@ -11,14 +11,14 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='XPDebug'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='XPRelease'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/src/Winfile.vcxproj
+++ b/src/Winfile.vcxproj
@@ -59,6 +59,17 @@
       <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='XPDebug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>DBG=1;DEBUG=1;STRSAFE_NO_DEPRECATE=1;WINVER=0x0501;_WIN32_WINNT=0x501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>DBG=1;DEBUG=1;STRSAFE_NO_DEPRECATE=1;WINVER=0x0501;_WIN32_WINNT=0x501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
       <PreprocessorDefinitions>DBG=1;DEBUG=1;WINVER=0x0A00;_WIN32_WINNT=0xA00;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -76,6 +87,17 @@
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='XPRelease|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>STRSAFE_NO_DEPRECATE=1;WINVER=0x0501;_WIN32_WINNT=0x501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>STRSAFE_NO_DEPRECATE=1;WINVER=0x0501;_WIN32_WINNT=0x501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
       <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>

--- a/src/Winfile.vcxproj
+++ b/src/Winfile.vcxproj
@@ -59,7 +59,7 @@
       <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='XPDebug|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugXPStatic|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>DBG=1;DEBUG=1;STRSAFE_NO_DEPRECATE=1;WINVER=0x0501;_WIN32_WINNT=0x501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
@@ -92,7 +92,7 @@
       <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='XPRelease|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseXPStatic|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>STRSAFE_NO_DEPRECATE=1;WINVER=0x0501;_WIN32_WINNT=0x501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>

--- a/src/lfn.c
+++ b/src/lfn.c
@@ -42,8 +42,11 @@ WFFindFirst(
    // and ORDINARY files too.
    //
 
-   PVOID oldValue;
-   Wow64DisableWow64FsRedirection(&oldValue);
+   PVOID oldValue = NULL;
+   if (Wow64DisableWow64FsRedirection != NULL)
+   {
+       Wow64DisableWow64FsRedirection(&oldValue);
+   }
 
    if ((dwAttrFilter & ~(ATTR_DIR | ATTR_HS)) == 0)
    {
@@ -68,7 +71,10 @@ WFFindFirst(
 
    lpFind->fd.dwFileAttributes &= ATTR_USED;
 
-   Wow64RevertWow64FsRedirection(oldValue);
+   if (Wow64RevertWow64FsRedirection != NULL)
+   {
+       Wow64RevertWow64FsRedirection(oldValue);
+   }
 
    //
    // Keep track of length
@@ -116,8 +122,11 @@ WFFindFirst(
 BOOL
 WFFindNext(LPLFNDTA lpFind)
 {
-   PVOID oldValue;
-   Wow64DisableWow64FsRedirection(&oldValue);
+   PVOID oldValue = NULL;
+   if (Wow64DisableWow64FsRedirection != NULL)
+   {
+       Wow64DisableWow64FsRedirection(&oldValue);
+   }
 
    while (FindNextFile(lpFind->hFindFile, &lpFind->fd)) {
 
@@ -154,7 +163,10 @@ WFFindNext(LPLFNDTA lpFind)
           }
       }
 
-      Wow64RevertWow64FsRedirection(oldValue);
+      if (Wow64RevertWow64FsRedirection != NULL)
+      {
+          Wow64RevertWow64FsRedirection(oldValue);
+      }
 
       lpFind->err = 0;
       return TRUE;
@@ -162,7 +174,10 @@ WFFindNext(LPLFNDTA lpFind)
 
    lpFind->err = GetLastError();
 
-   Wow64RevertWow64FsRedirection(oldValue);
+   if (Wow64RevertWow64FsRedirection != NULL)
+   {
+       Wow64RevertWow64FsRedirection(oldValue);
+   }
    return(FALSE);
 }
 
@@ -494,11 +509,20 @@ WFCopyIfSymlink(LPTSTR pszFrom, LPTSTR pszTo, DWORD dwFlags, DWORD dwNotificatio
 
    DWORD dwReparseTag = DecodeReparsePoint(pszFrom, szReparseDest, 2 * MAXPATHLEN);
 
-   if (IO_REPARSE_TAG_SYMLINK == dwReparseTag) {
-      CreateSymbolicLink(pszTo, szReparseDest, dwFlags | (bDeveloperModeAvailable ? SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE : 0));
-      dwRet = GetLastError();
-      if (ERROR_SUCCESS == dwRet) {
-         ChangeFileSystem(dwNotification, pszTo, NULL);
+   if (IO_REPARSE_TAG_SYMLINK == dwReparseTag)
+   {
+      if (CreateSymbolicLink == NULL)
+      {
+         dwRet = ERROR_NOT_SUPPORTED;
+      }
+      else
+      {
+         CreateSymbolicLink(pszTo, szReparseDest, dwFlags | (bDeveloperModeAvailable ? SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE : 0));
+         dwRet = GetLastError();
+         if (ERROR_SUCCESS == dwRet)
+         {
+            ChangeFileSystem(dwNotification, pszTo, NULL);
+         }
       }
    }
    else
@@ -518,11 +542,12 @@ WFCopy(LPTSTR pszFrom, LPTSTR pszTo)
 {
     DWORD dwRet;
     TCHAR szTemp[MAXPATHLEN];
+    BOOL bCancel = FALSE;
 
     Notify(hdlgProgress, IDS_COPYINGMSG, pszFrom, pszTo);
 
-    BOOL bCancel = FALSE;
-    if (CopyFileEx(pszFrom, pszTo, NULL, NULL, &bCancel, COPY_FILE_COPY_SYMLINK)) {
+    if (CopyFileEx(pszFrom, pszTo, NULL, NULL, &bCancel, COPY_FILE_COPY_SYMLINK))
+    {
         ChangeFileSystem(FSC_CREATE, pszTo, NULL);
         dwRet = 0;
     }
@@ -540,7 +565,8 @@ WFCopy(LPTSTR pszFrom, LPTSTR pszTo)
           //
           lstrcpy(szTemp, pszTo);
           RemoveLast(szTemp);
-          if (CopyFile(pszFrom, szTemp, FALSE)) {
+          if (CopyFile(pszFrom, szTemp, FALSE))
+          {
              ChangeFileSystem(FSC_CREATE, szTemp, NULL);
              dwRet = 0;
           }
@@ -588,11 +614,17 @@ WFSymbolicLink(LPTSTR pszFrom, LPTSTR pszTo, DWORD dwFlags)
    DWORD dwRet;
 
    Notify(hdlgProgress, IDS_COPYINGMSG, pszFrom, pszTo);
-
-   if (CreateSymbolicLink(pszTo, pszFrom, dwFlags | (bDeveloperModeAvailable ? SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE : 0))) {
+   if (CreateSymbolicLink == NULL)
+   {
+      dwRet = ERROR_NOT_SUPPORTED;
+   }
+   else if (CreateSymbolicLink(pszTo, pszFrom, dwFlags | (bDeveloperModeAvailable ? SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE : 0)))
+   {
       ChangeFileSystem(dwFlags == SYMBOLIC_LINK_FLAG_DIRECTORY ? FSC_SYMLINKD : FSC_CREATE, pszTo, NULL);
       dwRet = ERROR_SUCCESS;
-   } else {
+   }
+   else
+   {
       dwRet = GetLastError();
    }
 

--- a/src/tbar.c
+++ b/src/tbar.c
@@ -1232,8 +1232,9 @@ CreateFMToolbar(void)
    if (!hwndToolbar)
       return;
 
-   if (bDisableVisualStyles)
-     SetWindowTheme(hwndToolbar, pwszInvalidTheme, pwszInvalidTheme);
+   if (bDisableVisualStyles && SetWindowTheme != NULL) {
+      SetWindowTheme(hwndToolbar, pwszInvalidTheme, pwszInvalidTheme);
+   }
 
    SendMessage (hwndToolbar, TB_SETINDENT, 8, 0);
 
@@ -1257,8 +1258,9 @@ CreateFMToolbar(void)
       return;
    }
 
-   if (bDisableVisualStyles)
-     SetWindowTheme(hwndDriveList, pwszInvalidTheme, pwszInvalidTheme);
+   if (bDisableVisualStyles && SetWindowTheme != NULL) {
+      SetWindowTheme(hwndDriveList, pwszInvalidTheme, pwszInvalidTheme);
+   }
 
    SendMessage(hwndDriveList, CB_SETEXTENDEDUI, 0, 0L);
    SendMessage(hwndDriveList, WM_SETFONT, (WPARAM)hfontDriveList, MAKELPARAM(TRUE, 0));

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -839,7 +839,7 @@ GetPowershellExePath(LPTSTR szPSPath)
             DWORD dwInstall;
             DWORD dwType;
             DWORD cbValue = sizeof(dwInstall);
-            dwError = RegGetValue(hkey, szSub, TEXT("Install"), RRF_RT_DWORD, &dwType, (PVOID)&dwInstall, &cbValue);
+            dwError = WFRegGetValueW(hkey, szSub, TEXT("Install"), RRF_RT_DWORD, &dwType, (PVOID)&dwInstall, &cbValue);
 
             if (dwError == ERROR_SUCCESS && dwInstall == 1)
             {
@@ -853,7 +853,7 @@ GetPowershellExePath(LPTSTR szPSPath)
                     LPTSTR szPSExe = TEXT("\\Powershell.exe");
 
                     cbValue = (MAXPATHLEN - lstrlen(szPSExe)) * sizeof(TCHAR);
-                    dwError = RegGetValue(hkeySub, TEXT("PowerShellEngine"), TEXT("ApplicationBase"), RRF_RT_REG_SZ | RRF_RT_REG_EXPAND_SZ, &dwType, (PVOID)szPSPath, &cbValue);
+                    dwError = WFRegGetValueW(hkeySub, TEXT("PowerShellEngine"), TEXT("ApplicationBase"), RRF_RT_REG_SZ | RRF_RT_REG_EXPAND_SZ, &dwType, (PVOID)szPSPath, &cbValue);
 
                     if (dwError == ERROR_SUCCESS)
                     {

--- a/src/wfdirrd.c
+++ b/src/wfdirrd.c
@@ -50,7 +50,6 @@ LPXDTALINK CreateDTABlockWorker(HWND hwnd, HWND hwndDir);
 LPXDTALINK StealDTABlock(HWND hwndCur, LPWSTR pPath, DWORD dwAttribs);
 BOOL IsNetDir(LPWSTR pPath, LPWSTR pName);
 VOID DirReadAbort(HWND hwnd, LPXDTALINK lpStart, EDIRABORT eDirAbort);
-LONG WFRegGetValueW(HKEY hkey, LPCWSTR lpSubKey, LPCWSTR lpValue, LPDWORD pdwType, PVOID pvData, LPDWORD pcbData);
 
 BOOL
 InitDirRead(VOID)
@@ -539,14 +538,14 @@ BuildDocumentStringWorker()
 
          cbClass = sizeof(szClass);
          cbIconFile = 0;
-         if (WFRegGetValueW(hk, szT, NULL, NULL, szClass, &cbClass) == ERROR_SUCCESS)
+         if (WFRegGetValueW(hk, szT, NULL, RRF_RT_ANY, NULL, szClass, &cbClass) == ERROR_SUCCESS)
          {
             DWORD cbClass2;
             TCHAR szClass2[MAXPATHLEN];
 
             cbClass2 = sizeof(szClass2);
             lstrcat(szClass, L"\\CurVer");
-            if (WFRegGetValueW(hk, szClass, NULL, NULL, szClass2, &cbClass2) == ERROR_SUCCESS)
+            if (WFRegGetValueW(hk, szClass, NULL, RRF_RT_ANY, NULL, szClass2, &cbClass2) == ERROR_SUCCESS)
             {
                lstrcpy(szClass, szClass2);
             }
@@ -557,7 +556,7 @@ BuildDocumentStringWorker()
 
             cbIconFile = sizeof(szIconFile);
             lstrcat(szClass, L"\\DefaultIcon");
-            if (WFRegGetValueW(hk, szClass, NULL, NULL, szIconFile, &cbIconFile) != ERROR_SUCCESS)
+            if (WFRegGetValueW(hk, szClass, NULL, RRF_RT_ANY, NULL, szIconFile, &cbIconFile) != ERROR_SUCCESS)
             {
                cbIconFile = 0;
             }
@@ -1141,18 +1140,3 @@ IsNetDir(LPWSTR pPath, LPWSTR pName)
    return dwType;
 }
 
-// RegGetValue isn't available on Windows XP
-LONG WFRegGetValueW(HKEY hkey, LPCWSTR lpSubKey, LPCWSTR lpValue, LPDWORD pdwType, PVOID pvData, LPDWORD pcbData)
-{
-    DWORD dwStatus;
-    HKEY hkeySub;
-
-    if ((dwStatus = RegOpenKey(hkey, lpSubKey, &hkeySub)) == ERROR_SUCCESS)
-    {
-        dwStatus = RegQueryValueEx(hkeySub, lpValue, NULL, pdwType, pvData, pcbData);
-
-        RegCloseKey(hkeySub);
-    }
-
-    return dwStatus;
-}

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -991,6 +991,16 @@ InitFileManager(
 
    InitializeCriticalSection(&CriticalSectionPath);
 
+   hKernel32 = GetModuleHandle(KERNEL32_DLL);
+   if (hKernel32)
+   {
+      lpfnCreateSymbolicLinkW = (PVOID)GetProcAddress(hKernel32, KERNEL32_CreateSymbolicLinkW);
+      lpfnGetLocaleInfoEx = (PVOID)GetProcAddress(hKernel32, KERNEL32_GetLocaleInfoEx);
+      lpfnLocaleNameToLCID = (PVOID)GetProcAddress(hKernel32, KERNEL32_LocaleNameToLCID);
+      lpfnWow64DisableWow64FsRedirection = (PVOID)GetProcAddress(hKernel32, KERNEL32_Wow64DisableWow64FsRedirection);
+      lpfnWow64RevertWow64FsRedirection = (PVOID)GetProcAddress(hKernel32, KERNEL32_Wow64RevertWow64FsRedirection);
+   }
+
    // ProfStart();
 
    //
@@ -1018,7 +1028,7 @@ InitFileManager(
    GetPrivateProfileString(szSettings, szUILanguage, szNULL, szTemp, COUNTOF(szTemp), szTheINIFile);
    if (szTemp[0])
    {
-       LCID lcidUI = LocaleNameToLCID(szTemp, 0);
+       LCID lcidUI = WFLocaleNameToLCID(szTemp, 0);
        if (lcidUI != 0)
        {
            SetThreadUILanguage((LANGID)lcidUI);
@@ -1318,7 +1328,7 @@ JAPANEND
    win.rc.right -= win.rc.left;
    win.rc.bottom -= win.rc.top;
 
-   // We need to know about all reaprse tags
+   // We need to know about all reparse tags
    hNtdll = GetModuleHandle(NTDLL_DLL);
    if (hNtdll)
    {

--- a/src/wfloc.c
+++ b/src/wfloc.c
@@ -14,28 +14,72 @@ Licensed under the MIT License.
 The Language names are sorted like this because CBS_SORT Flag for comboboxes causes bugs.
 cf. https://msdn.microsoft.com/en-us/library/cc233982.aspx
 */
-LPCTSTR szLCIDs[] = {
-    TEXT("zh-CN"),    // Chinese, Simplified
-    TEXT("en-US"),    // English, United States
-    TEXT("he-IL"),    // Hebrew, Israel
-    TEXT("ja-JP"),    // Japanese, Japan
-    TEXT("pl-PL"),    // Polish, Poland
-    TEXT("de-DE"),    // German, Germany
-    TEXT("tr-TR"),    // Turkish, Turkey
-    TEXT("pt-PT"),    // Portuguese, Portugal
+
+typedef struct _FM_LANG {
+    LPCWSTR String;
+    LANGID Lang;
+} FM_LANG;
+
+FM_LANG fmLCIDs[] = {
+    {TEXT("zh-CN"), MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED)}, // Chinese, Simplified
+    {TEXT("en-US"), MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US)},         // English, United States
+    {TEXT("he-IL"), MAKELANGID(LANG_HEBREW, SUBLANG_HEBREW_ISRAEL)},       // Hebrew, Israel
+    {TEXT("ja-JP"), MAKELANGID(LANG_JAPANESE, SUBLANG_JAPANESE_JAPAN)},    // Japanese, Japan
+    {TEXT("pl-PL"), MAKELANGID(LANG_POLISH, SUBLANG_POLISH_POLAND)},       // Polish, Poland
+    {TEXT("de-DE"), MAKELANGID(LANG_GERMAN, SUBLANG_GERMAN)},              // German, Germany
+    {TEXT("tr-TR"), MAKELANGID(LANG_TURKISH, SUBLANG_TURKISH_TURKEY)},     // Turkish, Turkey
+    {TEXT("pt-PT"), MAKELANGID(LANG_PORTUGUESE, SUBLANG_PORTUGUESE)}       // Portuguese, Portugal
 };
+
+LCID
+WFLocaleNameToLCID(LPCWSTR lpName, DWORD dwFlags)
+{
+    LCID lcidTemp;
+    DWORD i;
+
+    lcidTemp = LOCALE_USER_DEFAULT;
+
+    if (LocaleNameToLCID != NULL)
+    {
+        lcidTemp = LocaleNameToLCID(lpName, 0);
+    }
+
+    for (i = 0; i <= COUNTOF(fmLCIDs) - 1; i++)
+    {
+        if (lstrcmpi(lpName, fmLCIDs[i].String) == 0)
+        {
+            lcidTemp = MAKELCID(fmLCIDs[i].Lang, SORT_DEFAULT);
+            break;
+        }
+    }
+
+    return lcidTemp;
+}
 
 VOID InitLangList(HWND hCBox)
 {
     // Propogate the list
-    for (UINT i = 0; i <= (COUNTOF(szLCIDs) - 1); i++)
+    for (UINT i = 0; i <= (COUNTOF(fmLCIDs) - 1); i++)
     {
         TCHAR szLangName[MAXPATHLEN] = { 0 };
-        LCID lcidTemp = LocaleNameToLCID(szLCIDs[i], 0);
+        LCID lcidTemp;
 
-        // TODO: need to test this on pre-Vista and on/after Win XP 64
-        if (GetLocaleInfoEx(szLCIDs[i], LOCALE_SLOCALIZEDDISPLAYNAME, szLangName, COUNTOF(szLangName)) == 0)
-            lstrcpy(szLangName, TEXT("BUGBUG"));
+        lcidTemp = WFLocaleNameToLCID(fmLCIDs[i].String, 0);
+
+        if (GetLocaleInfoEx != NULL)
+        {
+            if (GetLocaleInfoEx(fmLCIDs[i].String, LOCALE_SLOCALIZEDDISPLAYNAME, szLangName, COUNTOF(szLangName)) == 0)
+            {
+                lstrcpy(szLangName, TEXT("BUGBUG"));
+            }
+        }
+        else
+        {
+            if (GetLocaleInfo(lcidTemp, LOCALE_SLOCALIZEDDISPLAYNAME, szLangName, COUNTOF(szLangName)) == 0)
+            {
+                lstrcpy(szLangName, TEXT("BUGBUG"));
+            }
+        }
 
         // every entry in the array above needs to be addd to the list box;
         // SaveLang() below depends on each index in the listbox being valid.
@@ -56,7 +100,7 @@ VOID SaveLang(HWND hCBox)
     if (iIndex == CB_ERR)
         return; // do nothing
 
-    WritePrivateProfileString(szSettings, szUILanguage, szLCIDs[iIndex], szTheINIFile);
+    WritePrivateProfileString(szSettings, szUILanguage, fmLCIDs[iIndex].String, szTheINIFile);
 }
 
 // returns whether the current language is default RTL; ARABIC, HEBREW: true; else false;

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -69,17 +69,43 @@ typedef unsigned char TUCHAR, *PTUCHAR;
 #endif /* UNICODE */                // r_winnt
 
 
-////////////////////////////////////////////////////////////////////////////
 //
-//  File Compression stuff
+//  Define things that would be present on new SDKs but may not be present on
+//  older SDKs.  XP support uses a Windows 7.1 SDK, which is effectively the
+//  "oldest" that this code can use.
 //
-//  NOTE: This should be removed when FS_FILE_COMPRESSION is defined in a
-//        global header file.
-////////////////////////////////////////////////////////////////////////////
 
-#ifndef FS_FILE_COMPRESSION
-#define FS_FILE_COMPRESSION 0x0010
-#endif  //  FS_FILE_COMPRESSION
+#ifndef SYMBOLIC_LINK_FLAG_DIRECTORY
+#define SYMBOLIC_LINK_FLAG_DIRECTORY                  (0x01)
+#endif
+
+#ifndef SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
+#define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE  (0x02)
+#endif
+
+#ifndef COPY_FILE_COPY_SYMLINK
+#define COPY_FILE_COPY_SYMLINK                        (0x800)
+#endif
+
+#ifndef IO_REPARSE_TAG_CLOUD
+#define IO_REPARSE_TAG_CLOUD                          (0x9000001AL)
+#define IO_REPARSE_TAG_CLOUD_1                        (0x9000101AL)
+#define IO_REPARSE_TAG_CLOUD_2                        (0x9000201AL)
+#define IO_REPARSE_TAG_CLOUD_3                        (0x9000301AL)
+#define IO_REPARSE_TAG_CLOUD_4                        (0x9000401AL)
+#define IO_REPARSE_TAG_CLOUD_5                        (0x9000501AL)
+#define IO_REPARSE_TAG_CLOUD_6                        (0x9000601AL)
+#define IO_REPARSE_TAG_CLOUD_7                        (0x9000701AL)
+#define IO_REPARSE_TAG_CLOUD_8                        (0x9000801AL)
+#define IO_REPARSE_TAG_CLOUD_9                        (0x9000901AL)
+#define IO_REPARSE_TAG_CLOUD_A                        (0x9000A01AL)
+#define IO_REPARSE_TAG_CLOUD_B                        (0x9000B01AL)
+#define IO_REPARSE_TAG_CLOUD_C                        (0x9000C01AL)
+#define IO_REPARSE_TAG_CLOUD_D                        (0x9000D01AL)
+#define IO_REPARSE_TAG_CLOUD_E                        (0x9000E01AL)
+#define IO_REPARSE_TAG_CLOUD_F                        (0x9000F01AL)
+#define IO_REPARSE_TAG_CLOUD_MASK                     (0x0000F000L)
+#endif
 
 
 #define atoi atoiW
@@ -547,6 +573,7 @@ BOOL  IsRamDrive(DRIVE drive);
 VOID  CleanupMessages();
 HWND  GetRealParent(HWND hwnd);
 VOID  WFHelp(HWND hwnd);
+LONG  WFRegGetValueW(HKEY hkey, LPCWSTR lpSubKey, LPCWSTR lpValue, DWORD dwFlags, LPDWORD pdwType, PVOID pvData, LPDWORD pcbData);
 
 
 // WFDRIVES.C
@@ -616,6 +643,7 @@ BOOL WFCheckCompress(HWND hDlg, LPTSTR szNameSpec, DWORD dwNewAttrs, BOOL bPrope
 BOOL GetRootPath(LPTSTR szPath, LPTSTR szReturn);
 
 //WFLOC.C
+LCID WFLocaleNameToLCID(LPCWSTR lpName, DWORD dwFlags);
 VOID InitLangList(HWND hCBox);
 VOID SaveLang(HWND hCBox);
 BOOL DefaultLayoutRTL();
@@ -971,7 +999,36 @@ typedef struct _DRIVE_INFO {
 #define EQ(x)
 #endif
 
+//-------------------------------------
+//
+//  Lazy load post-XP function support
+//
+//-------------------------------------
 
+#define KERNEL32_DLL TEXT("kernel32.dll")
+Extern HANDLE hKernel32          EQ( NULL );
+
+Extern BOOLEAN (WINAPI* lpfnCreateSymbolicLinkW)(LPCWSTR, LPCWSTR, DWORD);
+Extern INT     (WINAPI* lpfnGetLocaleInfoEx)(LPCWSTR, LCTYPE, LPWSTR, INT);
+Extern LCID    (WINAPI* lpfnLocaleNameToLCID)(LPCWSTR, DWORD);
+Extern BOOL    (WINAPI* lpfnWow64DisableWow64FsRedirection)(PVOID *);
+Extern BOOL    (WINAPI* lpfnWow64RevertWow64FsRedirection)(PVOID);
+
+#define KERNEL32_CreateSymbolicLinkW            "CreateSymbolicLinkW"
+#define KERNEL32_GetLocaleInfoEx                "GetLocaleInfoEx"
+#define KERNEL32_LocaleNameToLCID               "LocaleNameToLCID"
+#define KERNEL32_Wow64DisableWow64FsRedirection "Wow64DisableWow64FsRedirection"
+#define KERNEL32_Wow64RevertWow64FsRedirection  "Wow64RevertWow64FsRedirection"
+
+#define CreateSymbolicLinkW            (*lpfnCreateSymbolicLinkW)
+#define GetLocaleInfoEx                (*lpfnGetLocaleInfoEx)
+#define LocaleNameToLCID               (*lpfnLocaleNameToLCID)
+#define Wow64DisableWow64FsRedirection (*lpfnWow64DisableWow64FsRedirection)
+#define Wow64RevertWow64FsRedirection  (*lpfnWow64RevertWow64FsRedirection)
+
+#ifndef CreateSymbolicLink
+#define CreateSymbolicLink  CreateSymbolicLinkW
+#endif
 
 //----------------------------
 //


### PR DESCRIPTION
### Background

Ever since this code was released, one of the most common things people do is backport to older systems.  There's been a few unofficial forks to do this, and one official branch in this repo.  What appears to happen each time though is people start from `master` then backport, as opposed to starting with an older build system then applying current changes.  Given that this seems to be a trend, it makes sense to just merge the changes needed for older systems into `master` so these backports are either unneeded or are substantially simpler.

The changes here target `v141_xp`; going older than XP with a Microsoft compiler would require Visual Studio 2008 or earlier and I think would require much more dramatic build system changes.  If the goal is just XP, the there's not much point using an older compiler than `v141_xp`.

### Substantive changes to do this

1. Build system support.  Craig had earlier expressed concern about not wanting to support two build systems for legacy support.  This is one thing that msbuild does fairly well though - because each configuration specifies its own compiler, it's easy enough to have one configuration that targets XP where others do not, so build system changes are minimal.
2. `RegGetValue` doesn't exist on XP and there had been a hand-coded replacement in `wfdirrd.c`.  This change expands that to be more compliant with the API - to enforce registry types via flags, and to guarantee to NULL terminate strings - then switches code over to use the replacement.
3. Previously multi language support worked by having a table of strings, and at runtime converting those into an `LCID`.  XP doesn't have this conversion function, so the table of strings becomes a table of string with `LCID`.  This change continues to call the API to do the conversion if it exists, although that part now seems redundant.  Strings are still needed for the .ini file.  Note that XP needs an `LCID` to find the language name, since it also doesn't have `GetLocaleInfoEx`.
4. Only disable WOW64 redirection if support to do so exists.
5. Symbolic link support is currently failed if it does not exist.  I'd like to go further and disable the menu items when support is not present, but this change does not go that far.
6. Add various defines that don't exist in the Windows 7.1 SDK which is used implicitly by the `v141_xp` target.

### Consequences

In theory, the XP binary should be fully functional on newer systems.  It probably won't be the released binary though, because I don't think it'll be possible to officially build and sign it given the tooling is no longer current.

There is one warning in the XP build that I can't see how to eliminate, saying the long path manifest entry is not recognized by the older toolchain.  It still seems correct to keep though, so the warning should be benign.  Note this warning does not exist for the regular build, only when targeting XP specifically.

This may introduce some pain for developers to test with `v141_xp`; it won't matter too much if this support regresses periodically, since it still solves the problem of reducing the work needed for people adding this support themselves.

It also seems to be the final nail in the coffin for the `retro` branch.  I'll start an issue for discussion on that, but this PR seems to support XP better than `retro` does and should be easier to support going forward. 
