### PR TITLE
Add an explicit save settings to make shift+exit behavior more discoverable

### DIFF
--- a/src/lang/res_de-DE.rc
+++ b/src/lang/res_de-DE.rc
@@ -99,10 +99,8 @@ BEGIN
     MENUITEM    "&Symbol nach Programmstart",                     IDM_MINONRUN
     MENUITEM    "Beim Starten &Goto-Index erstellen",             IDM_INDEXONLAUNCH
     MENUITEM    "&Einstellungen beim Beenden speichern",          IDM_SAVESETTINGS
-#ifdef PROGMAN
     MENUITEM    SEPARATOR
     MENUITEM    "Einstellungen jetzt speicher&n",                 IDM_SAVENOW
-#endif
     END
     POPUP       "&Sicherheit"
     BEGIN

--- a/src/lang/res_en-US.rc
+++ b/src/lang/res_en-US.rc
@@ -99,10 +99,8 @@ BEGIN
     MENUITEM    "&Minimize on Use",     IDM_MINONRUN
     MENUITEM    "Create &Goto Index on Launch", IDM_INDEXONLAUNCH
     MENUITEM    "Save Settings on &Exit",   IDM_SAVESETTINGS
-#ifdef PROGMAN
     MENUITEM    SEPARATOR
     MENUITEM    "Save Settings &Now",       IDM_SAVENOW
-#endif
     END
     POPUP       "&Security"
     BEGIN

--- a/src/lang/res_he-IL.rc
+++ b/src/lang/res_he-IL.rc
@@ -99,10 +99,8 @@ BEGIN
     MENUITEM    "&מזער בעת הפעלה",     IDM_MINONRUN
     MENUITEM    "צור מפתח Goto בעת ההפעלה", IDM_INDEXONLAUNCH
     MENUITEM    "&שמור הגדרות ביציאה",   IDM_SAVESETTINGS
-#ifdef PROGMAN
     MENUITEM    SEPARATOR
     MENUITEM    "שמירת הגדרות &עכשיו",       IDM_SAVENOW
-#endif
     END
     POPUP       "&אבטחה"
     BEGIN

--- a/src/lang/res_ja-JP.rc
+++ b/src/lang/res_ja-JP.rc
@@ -99,10 +99,8 @@ BEGIN
     MENUITEM    "プログラムの起動時に最小化(&M)",     IDM_MINONRUN
     MENUITEM    "起動時に移動先インデックスを作成(&G)", IDM_INDEXONLAUNCH
     MENUITEM    "終了時に設定を保存(&E)",   IDM_SAVESETTINGS
-#ifdef PROGMAN
     MENUITEM    SEPARATOR
     MENUITEM    "今すぐ設定を保存(&N)",       IDM_SAVENOW
-#endif
     END
     POPUP       "セキュリティ(&S)"
     BEGIN

--- a/src/lang/res_pl-PL.rc
+++ b/src/lang/res_pl-PL.rc
@@ -99,10 +99,8 @@ BEGIN
     MENUITEM    "&Minimalizuj podczas pracy",                 IDM_MINONRUN
     MENUITEM    "Twórz indeks katalogów przy &uruchomieniu",  IDM_INDEXONLAUNCH
     MENUITEM    "Z&apisz ustawienia przy zakończeniu",        IDM_SAVESETTINGS
-#ifdef PROGMAN
     MENUITEM    SEPARATOR
     MENUITEM    "Zapisz &ustawienia w tej chwili",            IDM_SAVENOW
-#endif
     END
     POPUP       "&Zabezpieczenia"
     BEGIN

--- a/src/lang/res_pt-PT.rc
+++ b/src/lang/res_pt-PT.rc
@@ -99,10 +99,8 @@ BEGIN
     MENUITEM    "Executar &Minimizado",     IDM_MINONRUN
     MENUITEM    "Criar &Index 'Ir para' ao Ligar", IDM_INDEXONLAUNCH
     MENUITEM    "&Guardar Definições ao Sair",   IDM_SAVESETTINGS
-#ifdef PROGMAN
     MENUITEM    SEPARATOR
     MENUITEM    "Guardar &Definições Agora",       IDM_SAVENOW
-#endif
     END
     POPUP       "&Segurança"
     BEGIN

--- a/src/lang/res_tr-TR.rc
+++ b/src/lang/res_tr-TR.rc
@@ -99,10 +99,8 @@ BEGIN
         MENUITEM    "K&ullanımda Simge Durumuna Küçült", IDM_MINONRUN
         MENUITEM    "&Başlangıçta Şuna Git İndeksi Oluştur", IDM_INDEXONLAUNCH
         MENUITEM    "Çıkışta &Ayarları Kaydet",     IDM_SAVESETTINGS
-#ifdef PROGMAN
-    MENUITEM    SEPARATOR
-    MENUITEM    "Ayarları Ş&imdi Kaydet",           IDM_SAVENOW
-#endif
+        MENUITEM    SEPARATOR
+        MENUITEM    "Ayarları Ş&imdi Kaydet",           IDM_SAVENOW
     END
     POPUP       "Gü&venlik"
     BEGIN

--- a/src/lang/res_zh-CN.rc
+++ b/src/lang/res_zh-CN.rc
@@ -99,10 +99,8 @@ BEGIN
     MENUITEM    "自动缩成图标(&M)",     IDM_MINONRUN
     MENUITEM    "在启动时创建“转到目录“索引(&G)", IDM_INDEXONLAUNCH
     MENUITEM    "退出时保存设置值(&E)",   IDM_SAVESETTINGS
-#ifdef PROGMAN
     MENUITEM    SEPARATOR
     MENUITEM    "Save Settings &Now",       IDM_SAVENOW
-#endif
     END
     POPUP       "安全(&S)"
     BEGIN

--- a/src/res.h
+++ b/src/res.h
@@ -163,14 +163,11 @@
 #define IDM_SAVESETTINGS    511
 
 #define IDM_TOOLBARCUST     512
-
-#ifdef PROGMAN
 #define IDM_SAVENOW         513
-#endif
 
 #define IDM_INDEXONLAUNCH   514
 
-#define IDM_PREF          515
+#define IDM_PREF            515
 
 #define IDM_SECURITY        5
 #define IDM_PERMISSIONS     605      // !! WARNING HARD CODED !!

--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -1558,12 +1558,10 @@ AppCommandProc(DWORD id)
       break;
    }
 
-#ifdef PROGMAN
    case IDM_SAVENOW:
 
       SaveWindows(hwndFrame);
       break;
-#endif
 
    case IDM_EXIT:
 


### PR DESCRIPTION
This is for #245 .  Shift+exit currently saves settings, but it's not obvious to anyone that it does, so it doesn't seem to hurt to have an explicit option.

My biggest concern with this is the name - "Settings" as in things in the Options menu are saved immediately.  This option is about saving open window locations.