### PR TITLE
Compile XP builds for XP CPUs (aka, no SSE)

### DIFF
--- a/build/Winfile.props
+++ b/build/Winfile.props
@@ -17,6 +17,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebugDLL</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(Configuration)'=='DebugXPStatic'">MultiThreadedDebug</RuntimeLibrary>
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)'=='DebugXPStatic'">NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='ReleaseXPStatic'">
@@ -26,6 +27,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <RuntimeLibrary Condition="'$(Configuration)'=='Release'">MultiThreadedDLL</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(Configuration)'=='ReleaseXPStatic'">MultiThreaded</RuntimeLibrary>
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)'=='ReleaseXPStatic'">NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <OptimizeReferences>true</OptimizeReferences>


### PR DESCRIPTION
These days there aren't many pre-SSE2 CPUs floating around, and it's basically a requirement for Windows 7 and up.  On XP, the base requirement is a Pentium 1 (not even Pentium Pro.)  WinFile could require a newer CPU than XP, but these instructions seem to be of limited value to it anyway, so there doesn't seem to be a good reason to stick with the SSE2 compiler default.

I dumped out the assembly from this and verified that `cmov` instructions are only used under runtime checks.  They're still used conditionally in `strchr` and `strrchr` operations.