### PR TITLE
Allow user to open a single directory on the command line

### DIFF
--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -1566,8 +1566,6 @@ JAPANEND
    InvalidateRect(hwndDriveList, NULL, TRUE);
 
 
-
-
    //
    // Init Menus fast stuff
    //

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -760,7 +760,9 @@ CheckDirExists(
 
 
 BOOL
-CreateSavedWindows()
+CreateSavedWindows(
+    LPCWSTR pszInitialDir
+    )
 {
    WCHAR buf[2*MAXPATHLEN+7*7], key[10];
    WINDOW win;
@@ -781,56 +783,90 @@ CreateSavedWindows()
    nDirNum = 1;
    iNumTrees = 0;
 
-   do {
-      wsprintf(key, szDirKeyFormat, nDirNum++);
+   if (pszInitialDir == NULL)
+   {
+      do
+      {
+         wsprintf(key, szDirKeyFormat, nDirNum++);
 
-      GetPrivateProfileString(szSettings, key, szNULL, buf, COUNTOF(buf), szTheINIFile);
+         GetPrivateProfileString(szSettings, key, szNULL, buf, COUNTOF(buf), szTheINIFile);
 
-      if (*buf) {
+         if (*buf)
+         {
+            GetSavedWindow(buf, &win);
 
-         GetSavedWindow(buf, &win);
+            //
+            // clean off some junk so we
+            // can do this test
+            //
+            lstrcpy(szDir, win.szDir);
+            StripFilespec(szDir);
+            StripBackslash(szDir);
 
-         //
-         // clean off some junk so we
-         // can do this test
-         //
-         lstrcpy(szDir, win.szDir);
-         StripFilespec(szDir);
-         StripBackslash(szDir);
+            if (!CheckDirExists(szDir)) {
+               continue;
+            }
 
-         if (!CheckDirExists(szDir))
-            continue;
+            dwNewView = win.dwView;
+            dwNewSort = win.dwSort;
+            dwNewAttribs = win.dwAttribs;
 
-         dwNewView = win.dwView;
-         dwNewSort = win.dwSort;
-         dwNewAttribs = win.dwAttribs;
+            hwnd = CreateTreeWindow(win.szDir,
+                                    win.rc.left,
+                                    win.rc.top,
+                                    win.rc.right - win.rc.left,
+                                    win.rc.bottom - win.rc.top,
+                                    win.nSplit);
 
-         hwnd = CreateTreeWindow(win.szDir,
-                                 win.rc.left,
-                                 win.rc.top,
-                                 win.rc.right - win.rc.left,
-                                 win.rc.bottom - win.rc.top,
-                                 win.nSplit);
+            if (!hwnd) {
+               continue;
+            }
 
-         if (!hwnd) {
-            continue;
+            iNumTrees++;
+
+            //
+            // keep track of this for now...
+            //
+            if (IsIconic(hwnd)) {
+               SetWindowPos(hwnd, NULL, win.pt.x, win.pt.y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+            }
+
+            ShowWindow(hwnd, win.sw);
          }
 
-         iNumTrees++;
-
-         //
-         // keep track of this for now...
-         //
-         if (IsIconic(hwnd))
-             SetWindowPos(hwnd, NULL, win.pt.x, win.pt.y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
-
-         ShowWindow(hwnd, win.sw);
-      }
-
-   } while (*buf);
+      } while (*buf);
+   }
 
    //
-   // if nothing was saved create a tree for the current drive
+   //  If the user requested to open the program with a specific directory,
+   //  open it
+   //
+
+   if (pszInitialDir != NULL){
+
+      lstrcpy(buf, pszInitialDir);
+      AddBackslash(buf);
+      lstrcat(buf, szStarDotStar);
+
+      //
+      // default to split window
+      //
+      hwnd = CreateTreeWindow(buf, CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, -1);
+
+      if (!hwnd)
+         return FALSE;
+
+      //
+      // Default to maximized since the user requested to open a single
+      // directory
+      //
+      ShowWindow(hwnd, SW_MAXIMIZE);
+
+      iNumTrees++;
+   }
+
+   //
+   // if nothing was saved or specified, create a tree for the current drive
    //
    if (!iNumTrees) {
 
@@ -984,6 +1020,7 @@ InitFileManager(
    HANDLE        hThread;
    DWORD         dwRetval;
    DWORD         dwExStyle = 0L;
+   LPWSTR        pszInitialDir = NULL;
 
    hThread = GetCurrentThread();
 
@@ -1007,9 +1044,6 @@ InitFileManager(
    // Preserve this instance's module handle
    //
    hAppInstance = hInstance;
-
-   if (*lpCmdLine)
-      nCmdShow = SW_SHOWMINNOACTIVE;
 
    // setup ini file location
    lstrcpy(szTheINIFile, szBaseINIFile);
@@ -1073,18 +1107,45 @@ JAPANEND
    //
    GetCurrentDirectory(COUNTOF(szOriginalDirPath), szOriginalDirPath);
 
-   if (*lpCmdLine) {
+   if (*lpCmdLine)
+   {
+      LPWSTR lpArgs;
 
-      if (dwRetval = ExecProgram(lpCmdLine, pszNextComponent(lpCmdLine), NULL, FALSE, FALSE))
-         MyMessageBox(NULL, IDS_EXECERRTITLE, dwRetval, MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
+      //
+      //  Note this isn't just finding the next argument, it's NULL
+      //  terminating lpCmdLine at the point of the next argument
+      //
+      lpArgs = pszNextComponent(lpCmdLine);
+      lpCmdLine = pszRemoveSurroundingQuotes(lpCmdLine);
+
+      if (WFIsDir(lpCmdLine))
+      {
+         pszInitialDir = lpCmdLine;
+      }
       else
+      {
          nCmdShow = SW_SHOWMINNOACTIVE;
+
+         dwRetval = ExecProgram(lpCmdLine, lpArgs, NULL, FALSE, FALSE);
+         if (dwRetval != 0)
+         {
+            MyMessageBox(NULL, IDS_EXECERRTITLE, dwRetval, MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
+         }
+      }
    }
 
    //
    // Read WINFILE.INI and set the appropriate variables.
    //
    GetSettings();
+
+   //
+   // If the user specified an initial directory on the command line, that
+   // directory will be opened, and save settings is disabled by default.
+   //
+   if (pszInitialDir != NULL) {
+      bSaveSettings = FALSE;
+   }
 
    dwExStyle = MainWindowExStyle();
 
@@ -1456,8 +1517,9 @@ JAPANEND
    //
    if (nCmdShow == SW_SHOW || nCmdShow == SW_SHOWNORMAL &&
       win.sw != SW_SHOWMINIMIZED)
-
+   {
       nCmdShow = win.sw;
+   }
 
    ShowWindow(hwndFrame, nCmdShow);
 
@@ -1504,6 +1566,8 @@ JAPANEND
    InvalidateRect(hwndDriveList, NULL, TRUE);
 
 
+
+
    //
    // Init Menus fast stuff
    //
@@ -1512,7 +1576,7 @@ JAPANEND
    InitMenus();
 
 
-   if (!CreateSavedWindows()) {
+   if (!CreateSavedWindows(pszInitialDir)) {
       return FALSE;
    }
 

--- a/src/wfutil.c
+++ b/src/wfutil.c
@@ -76,7 +76,7 @@ pszNextComponent(
       if ((*p == L' ' || *p == L'\t') && !bInQuotes)
          break;
 
-      if (*p == L'\"')
+      if (*p == CHAR_DQUOTE)
          bInQuotes = !bInQuotes;
 
       p++;
@@ -87,6 +87,31 @@ pszNextComponent(
 
       while (*p == L' ' || *p == L'\t')
          p++;
+   }
+
+   return p;
+}
+
+// If a string starts and ends with a quote, truncate the ending quote and
+// return a pointer to the new string start.  Note that parsing such as
+// pszNextComponent above support quotes in the middle of strings, which
+// this function makes no attempt to remove.
+LPWSTR
+pszRemoveSurroundingQuotes(
+   LPWSTR p
+   )
+{
+   if (*p == CHAR_DQUOTE) {
+      size_t len;
+
+      len = wcslen(p);
+
+      // Length needs to be at least 2 to ensure there are 2 quotes rather
+      // than counting the same quote twice
+      if (len > 1 && p[len - 1] == CHAR_DQUOTE) {
+         p[len - 1] = '\0';
+         p++;
+      }
    }
 
    return p;

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -417,6 +417,7 @@ VOID ExtSelItemsInvalidate();
 // WFUTIL.C
 
 LPWSTR pszNextComponent(LPWSTR pszCmdLine);
+LPWSTR pszRemoveSurroundingQuotes(LPWSTR p);
 VOID cdecl SetStatusText(INT nPane, UINT nFormat, LPCTSTR szFormat, ...);
 VOID RefreshWindow(HWND hwndActive, BOOL bUpdateDriveList, BOOL bFlushCache);
 BOOL IsLastWindow(VOID);
@@ -527,7 +528,7 @@ VOID  InitDriveBitmaps(VOID);
 VOID  InitExtensions(VOID);
 VOID  FreeFileManager(VOID);
 VOID  DeleteBitmaps(VOID);
-BOOL  CreateSavedWindows(VOID);
+BOOL  CreateSavedWindows(LPCWSTR pszInitialDir);
 VOID  InitExtensions(VOID);
 INT   GetDriveOffset(DRIVE drive);
 VOID  InitMenus(VOID);
@@ -1211,30 +1212,30 @@ JAPANBEGIN
 Extern BOOL   bJapan      EQ( FALSE );
 JAPANEND
 
-Extern BOOL bMinOnRun        EQ( FALSE );
-Extern BOOL bIndexOnLaunch   EQ( TRUE );
-Extern BOOL bStatusBar       EQ( TRUE );
+Extern BOOL bMinOnRun            EQ( FALSE );
+Extern BOOL bIndexOnLaunch       EQ( TRUE );
+Extern BOOL bStatusBar           EQ( TRUE );
 
 Extern BOOL bDriveBar            EQ( TRUE );
 Extern BOOL bToolbar             EQ( TRUE );
 Extern BOOL bNewWinOnConnect     EQ( TRUE );
 Extern BOOL bDisableVisualStyles EQ( FALSE );
-Extern BOOL bMirrorContent    EQ( FALSE );
+Extern BOOL bMirrorContent       EQ( FALSE );
 
-Extern BOOL bExitWindows     EQ( FALSE );
-Extern BOOL bConfirmDelete   EQ( TRUE );
-Extern BOOL bConfirmSubDel   EQ( TRUE );
-Extern BOOL bConfirmReplace  EQ( TRUE );
-Extern BOOL bConfirmMouse    EQ( TRUE );
-Extern BOOL bConfirmFormat   EQ( TRUE );
-Extern BOOL bConfirmReadOnly EQ( TRUE );
+Extern BOOL bExitWindows         EQ( FALSE );
+Extern BOOL bConfirmDelete       EQ( TRUE );
+Extern BOOL bConfirmSubDel       EQ( TRUE );
+Extern BOOL bConfirmReplace      EQ( TRUE );
+Extern BOOL bConfirmMouse        EQ( TRUE );
+Extern BOOL bConfirmFormat       EQ( TRUE );
+Extern BOOL bConfirmReadOnly     EQ( TRUE );
 
-Extern BOOL bSaveSettings    EQ( TRUE );
-Extern BOOL bScrollOnExpand  EQ( TRUE );
+Extern BOOL bSaveSettings        EQ( TRUE );
+Extern BOOL bScrollOnExpand      EQ( TRUE );
 
-Extern BOOL bConnectable       EQ( FALSE );
-Extern INT  iShowSourceBitmaps EQ( 1 );
-Extern BOOL bFSCTimerSet       EQ( FALSE );
+Extern BOOL bConnectable         EQ( FALSE );
+Extern INT  iShowSourceBitmaps   EQ( 1 );
+Extern BOOL bFSCTimerSet         EQ( FALSE );
 
 Extern TCHAR        chFirstDrive;           // 'A' or 'a'
 


### PR DESCRIPTION
This is to fix #266 .

Some (arbitrary) choices that try to guess what a user would want in this situation:
- Only one directory can be specified on the command line.  If the first argument matches a directory, it is opened, and subsequent arguments are ignored.  If it's not a directory, the previous execute flow is used.
- Any saved windows are not opened if a directory is specified.
- That directory is opened maximized, since there can only be one.
- When opened in this way, Winfile will not automatically save settings on exit, even if that is the user's preference.  This can be toggled, or an explicit save can be triggered.