### PR TITLE
Initial conversion to LoadLibrary from system directory

### DIFF
--- a/src/wfcomman.c
+++ b/src/wfcomman.c
@@ -790,7 +790,7 @@ FmifsLoaded()
    // Load the fmifs dll.
 
    if (hfmifsDll < (HANDLE)32) {
-      hfmifsDll = LoadLibrary(szFmifsDll);
+      hfmifsDll = LoadSystemLibrary(FMIFS_DLL);
       if (hfmifsDll < (HANDLE)32) {
          /* FMIFS not available. */
          MyMessageBox(hwndFrame, IDS_WINFILE, IDS_FMIFSLOADERR, MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);

--- a/src/wfdlgs2.c
+++ b/src/wfdlgs2.c
@@ -963,7 +963,7 @@ GetVersionInfo(PTSTR pszPath, PTSTR pszName)
 
    if (!hVersion) {
 
-      hVersion = LoadLibrary(VERSION_DLL);
+      hVersion = LoadSystemLibrary(VERSION_DLL);
 
       if (!hVersion) {
          bDLLFail = TRUE;

--- a/src/wfinfo.c
+++ b/src/wfinfo.c
@@ -1688,7 +1688,7 @@ NetLoad(VOID)
    TCHAR szPath[] = SZ_ACOLONSLASH;
 
    if (WNetStat(NS_CONNECT))  {
-      hMPR = LoadLibrary(MPR_DLL);
+      hMPR = LoadSystemLibrary(MPR_DLL);
 
       if (!hMPR)
          return FALSE;
@@ -1736,7 +1736,7 @@ NetLoad(VOID)
 
    if (WNetStat(NS_SHAREDLG)) {
 
-      hNtshrui = LoadLibrary(NTSHRUI_DLL);
+      hNtshrui = LoadSystemLibrary(NTSHRUI_DLL);
 
       if (hNtshrui) {
          lpfnShowShareFolderUI = (PVOID)GetProcAddress(hNtshrui, "ShowShareFolderUI");
@@ -1769,7 +1769,7 @@ NetLoad(VOID)
    // Try loading acledit.  If we fail, then gray out the button and
    // remove the popup menu.
    //
-   hAcledit = LoadLibrary(ACLEDIT_DLL);
+   hAcledit = LoadSystemLibrary(ACLEDIT_DLL);
 
    hMenuFrame = GetMenu(hwndFrame);
 
@@ -2004,7 +2004,7 @@ LoadComdlg(VOID)
    // Let the system handle errors here
    //
    uErrorMode = SetErrorMode(0);
-   hComdlg = LoadLibrary(COMDLG_DLL);
+   hComdlg = LoadSystemLibrary(COMDLG_DLL);
    SetErrorMode(uErrorMode);
 
    if (!hComdlg)

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -1761,7 +1761,7 @@ LoadUxTheme(VOID)
   // Let the system handle errors here
   //
   uErrorMode = SetErrorMode(0);
-  hUxTheme = LoadLibrary(UXTHEME_DLL);
+  hUxTheme = LoadSystemLibrary(UXTHEME_DLL);
   SetErrorMode(uErrorMode);
 
   if (!hUxTheme)

--- a/src/wfutil.c
+++ b/src/wfutil.c
@@ -1743,3 +1743,47 @@ LONG WFRegGetValueW(HKEY hkey, LPCWSTR lpSubKey, LPCWSTR lpValue, DWORD dwFlags,
 
     return dwStatus;
 }
+
+LPTSTR GetFullPathInSystemDirectory(LPCTSTR FileName)
+{
+    UINT LengthRequired;
+    UINT LengthReturned;
+    UINT FileNameLength;
+    LPTSTR FullPath;
+
+    LengthRequired = GetSystemDirectory(NULL, 0);
+    if (LengthRequired == 0) {
+        return NULL;
+    }
+
+    FileNameLength = lstrlen(FileName);
+    FullPath = LocalAlloc(LMEM_FIXED, (LengthRequired + 1 + FileNameLength + 1) * sizeof(TCHAR));
+    if (FullPath == NULL) {
+        return NULL;
+    }
+
+    LengthReturned = GetSystemDirectory(FullPath, LengthRequired);
+    if (LengthReturned == 0 || LengthReturned > LengthRequired) {
+        LocalFree(FullPath);
+        return NULL;
+    }
+
+    FullPath[LengthReturned] = '\\';
+    lstrcpy(&FullPath[LengthReturned + 1], FileName);
+    return FullPath;
+}
+
+HMODULE LoadSystemLibrary(LPCTSTR FileName)
+{
+    LPTSTR FullPath;
+    HMODULE Module;
+
+    FullPath = GetFullPathInSystemDirectory(FileName);
+    if (FullPath == NULL) {
+        return NULL;
+    }
+
+    Module = LoadLibrary(FullPath);
+    LocalFree(FullPath);
+    return Module;
+}

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -572,7 +572,8 @@ VOID  CleanupMessages();
 HWND  GetRealParent(HWND hwnd);
 VOID  WFHelp(HWND hwnd);
 LONG  WFRegGetValueW(HKEY hkey, LPCWSTR lpSubKey, LPCWSTR lpValue, DWORD dwFlags, LPDWORD pdwType, PVOID pvData, LPDWORD pcbData);
-
+LPTSTR GetFullPathInSystemDirectory(LPCTSTR FileName);
+HMODULE LoadSystemLibrary(LPCTSTR FileName);
 
 // WFDRIVES.C
 
@@ -1069,10 +1070,11 @@ BOOL LoadUxTheme(VOID);
 //
 //----------------------------
 
-#define MPR_DLL      TEXT("mpr.dll")
-#define NTSHRUI_DLL  TEXT("Ntshrui.dll")
 #define ACLEDIT_DLL  TEXT("acledit.dll")
+#define FMIFS_DLL    TEXT("fmifs.dll")
+#define MPR_DLL      TEXT("mpr.dll")
 #define NTDLL_DLL    TEXT("ntdll.dll")
+#define NTSHRUI_DLL  TEXT("Ntshrui.dll")
 
 #define WAITNET()      WaitLoadEvent(TRUE)
 #define WAITACLEDIT()  WaitLoadEvent(FALSE)
@@ -1428,7 +1430,6 @@ Extern HHOOK hhkMsgFilter     EQ( NULL );
 Extern DWORD dwContext       EQ( 0 );
 Extern DWORD nLastDriveInd   EQ( 0 );
 Extern DWORD fFormatFlags    EQ( 0 );
-Extern TCHAR szFmifsDll[]    EQ( TEXT("fmifs.dll") );
 
 Extern   CANCEL_INFO CancelInfo;
 Extern   SEARCH_INFO SearchInfo;


### PR DESCRIPTION
This started as a change to address #187 by constructing fully specified paths to system DLLs.  KnownDLLs already mitigates this type of attack, but it's good to be explicit.

This does not address addons; those seem like less of a security issue since an attacker would need to modify Winfile.ini to refer to one, and if they can do that, they probably already have access.  About the most sinister thing I can think of is code running in user context that believes the user will elevate Winfile, so modifying Winfile.ini allows for EOP; but doing that can be done without DLL planting.

Note, although it seems moot, that Undelete was building a system path then ignoring it (which is what made me ask #432 .)  Looking at the history of this code, I think it started as a performance optimization - originally it would explicitly look in the System directory for the DLL, and if it's there, call LoadLibrary without specifying a path.