### PR TITLE
Updates to nuspec based on previous choco submission

### DIFF
--- a/nuget/winfile.nuspec
+++ b/nuget/winfile.nuspec
@@ -7,15 +7,18 @@
     <authors>Microsoft, WinFile OSS Contributors</authors>
     <owners>https://github.com/craigwi</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <licenseUrl>https://github.com/Microsoft/winfile/raw/master/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/Microsoft/winfile</projectUrl>
+    <bugTrackerUrl>https://github.com/Microsoft/winfile/issues</bugTrackerUrl>
     <iconUrl>https://github.com/Microsoft/winfile/blob/master/winfile.png</iconUrl>
-    <description>Windows File Manager (WinFile) was originally released with Windows 3.0 in the early 1990s. You can read more about the history at https://en.wikipedia.org/wiki/File_Manager_(Windows).</description>
+    <licenseUrl>https://github.com/Microsoft/winfile/raw/master/LICENSE</licenseUrl>
+    <projectSourceUrl>https://github.com/Microsoft/winfile</projectSourceUrl>
+    <projectUrl>https://github.com/Microsoft/winfile</projectUrl>
+    <releaseNotes>https://github.com/Microsoft/winfile/releases</releaseNotes>
+    <description>Windows File Manager (WinFile) was originally released with Windows 3.0 in the early 1990s. You can read more about the history at https://en.wikipedia.org/wiki/Windows_File_Manager.</description>
     <summary>WinFile is the predecessor to the Windows Explorer and now runs on modern Windows, including Windows 10.</summary>
     <copyright>Copyright (c) Microsoft Corporation. All rights reserved.</copyright>
-	<tags>file manager utilities tools</tags>
+    <tags>file manager utilities tools</tags>
     <dependencies>
-      <dependency id='vcredist140' />
+      <dependency id='vcredist140' version='14.38.33135' />
     </dependencies>
   </metadata>
   <files>
@@ -23,7 +26,7 @@
     <file src="VERIFICATION.txt" target="legal\VERIFICATION.txt" />
     <file src="x86\Winfile.exe" target="tools\x86\Winfile.exe" />
     <file src="x86\Winfile.pdb" target="tools\x86\Winfile.pdb" />
-	<file src="help\winfile.chm" target="tools\x86\winfile.chm" />
+    <file src="help\winfile.chm" target="tools\x86\winfile.chm" />
     <file src="x64\Winfile.exe" target="tools\x64\Winfile.exe" />
     <file src="x64\Winfile.pdb" target="tools\x64\Winfile.pdb" />
     <file src="arm64\Winfile.exe" target="tools\arm64\Winfile.exe" />


### PR DESCRIPTION
As part of submitting a new release, Chocolatey issued a handful of warnings.  These weren't fatal to the release, but seem good to address before the next submission.  Most of them are around nuspec schema changes that didn't exist when the nuspec was written.