### PR TITLE
Enable SdlCheck and fix warning for use of uninitialized pointer value

### DIFF
--- a/build/Winfile.props
+++ b/build/Winfile.props
@@ -11,24 +11,42 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='DebugXPStatic'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebugDLL</RuntimeLibrary>
-      <RuntimeLibrary Condition="'$(Configuration)'=='DebugXPStatic'">MultiThreadedDebug</RuntimeLibrary>
-      <EnableEnhancedInstructionSet Condition="'$(Configuration)'=='DebugXPStatic'">NoExtensions</EnableEnhancedInstructionSet>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <SdlCheck>true</SdlCheck>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='ReleaseXPStatic'">
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='DebugXPStatic'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <RuntimeLibrary Condition="'$(Configuration)'=='Release'">MultiThreadedDLL</RuntimeLibrary>
-      <RuntimeLibrary Condition="'$(Configuration)'=='ReleaseXPStatic'">MultiThreaded</RuntimeLibrary>
-      <EnableEnhancedInstructionSet Condition="'$(Configuration)'=='ReleaseXPStatic'">NoExtensions</EnableEnhancedInstructionSet>
-      <Optimization Condition="'$(Configuration)'=='ReleaseXPStatic'">MinSpace</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <SdlCheck>true</SdlCheck>
+    </ClCompile>
+    <Link>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='ReleaseXPStatic'">
+    <ClCompile>
+      <Optimization>MinSpace</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <OptimizeReferences>true</OptimizeReferences>

--- a/src/treectl.c
+++ b/src/treectl.c
@@ -616,19 +616,19 @@ ReadDirLevel(
    LPTSTR  szAutoExpand,
    BOOL bPartialSort)
 {
-   LPWSTR      szEndPath;
+   LPWSTR    szEndPath;
    LFNDTA    lfndta;
    INT       iNode;
    BOOL      bFound;
-   PDNODE     pNode;
+   PDNODE    pNode;
    BOOL      bAutoExpand;
    BOOL      bResult = TRUE;
    DWORD     dwView;
    HWND      hwndParent;
    HWND      hwndDir;
    LPXDTALINK lpStart;
-   LPXDTA*  plpxdta;
-   LPXDTA   lpxdta;
+   LPXDTA*   plpxdta;
+   LPXDTA    lpxdta;
    INT       count;
 
    UINT      uYieldCount = 0;
@@ -649,6 +649,8 @@ ReadDirLevel(
    //
 
    lpStart = NULL;
+   plpxdta = NULL;
+   lpxdta = NULL;
 
    if (!(dwView & VIEW_PLUSES)) {
 
@@ -1034,6 +1036,8 @@ StealTreeData(
    DWORD dwView;
    DWORD dwAttribs;
 
+   hwndT = NULL;
+
    //
    // we need to match on these attributes as well as the name
    //
@@ -1159,6 +1163,7 @@ FillTreeListbox(HWND hwndTC,
    BOOL bPartialSort;
    DRIVE drive;
 
+   pNode = NULL;
 
    hwndLB = GetDlgItem(hwndTC, IDCW_TREELISTBOX);
 
@@ -1226,7 +1231,9 @@ FillTreeListbox(HWND hwndTC,
       FindItemFromPath(hwndLB, szDefaultDir, FALSE, NULL, &pNode);
    }
 
-   SendMessage(hwndLB, LB_SELECTSTRING, (WPARAM)-1, (LPARAM)pNode);
+   if (pNode != NULL) {
+      SendMessage(hwndLB, LB_SELECTSTRING, (WPARAM)-1, (LPARAM)pNode);
+   }
 
    UpdateStatus(GetParent(hwndTC));  // Redraw the Status Bar
 
@@ -3170,6 +3177,7 @@ SameSelection:
          BOOL bDir;
          BOOL bChangeDisplay = FALSE;
 
+         hwndNext = NULL;
          TypeAheadString('\0', NULL);
          GetTreeWindows(hwndParent, NULL, &hwndDir);
 
@@ -3207,7 +3215,7 @@ SameSelection:
                }
                else
                {
-                   hwndSet = hwnd;
+                  hwndSet = hwnd;
                }
             }
          }

--- a/src/wfassoc.c
+++ b/src/wfassoc.c
@@ -1783,6 +1783,9 @@ ClassesRead(HKEY hKey,
 
    iKey = 0;
 
+   pFileType = NULL;
+   pExt = NULL;
+
    pFileTypePrev = *ppFileTypeBase;
    pExtPrev = *ppExtBase;
 

--- a/src/wfcopy.c
+++ b/src/wfcopy.c
@@ -265,7 +265,7 @@ JAPANBEGIN
     // Allocate enough space for 8.3 conversion to DBCS here (each
     // part done individually, so 8 chars is enough).
     //
-    LPSTR pOrigA;
+    LPSTR pOrigA = NULL;
     CHAR szOrigA[8*2];
 JAPANEND
 
@@ -1403,6 +1403,7 @@ GetNextPair(PCOPYROOT pcr, LPTSTR pFrom,
    STKCHK();
    *pFrom = CHAR_NULL;
    *pdwError = 0 ;
+   pDTA = NULL;
 
    //
    // Keep recursing directory structure until we get to the bottom
@@ -2224,7 +2225,7 @@ WFMoveCopyDriverThread(LPVOID lpParameter)
 {
    PCOPYINFO pCopyInfo = lpParameter;
    DWORD ret = 0;                     // Return value from WFMoveCopyDriver
-   LPWSTR pSpec;                      // Pointer to file spec
+   LPWSTR pSpec = NULL;               // Pointer to file spec
    DWORD dwAttr;                      // File attributes
    DWORD dwResponse;                  // Response from ConfirmDialog call
    DWORD oper = 0;                    // Disk operation being performed
@@ -2235,7 +2236,7 @@ WFMoveCopyDriverThread(LPVOID lpParameter)
 
    TCHAR szSource[MAXPATHLEN];         // Source file (ANSI string)
    LFNDTA DTADest;                    // DTA block for reporting dest errors
-   PLFNDTA pDTA;                      // DTA pointer for source errors
+   PLFNDTA pDTA = NULL;               // DTA pointer for source errors
    PCOPYROOT pcr;                     // Structure for searching source tree
    BOOL bReplaceAll = FALSE;          // Replace all flag
    BOOL bSubtreeDelAll = FALSE;       // Delete entire subtree flag

--- a/src/wfdir.c
+++ b/src/wfdir.c
@@ -1318,6 +1318,8 @@ ChangeDisplay(
 
    case WM_CREATE:
 
+      lpStart = NULL;
+
       //
       // dwNewView, dwNewSort and dwNewAttribs define the viewing
       // parameters of the new window (GLOBALS)

--- a/src/wfdrives.c
+++ b/src/wfdrives.c
@@ -749,6 +749,8 @@ DrivesWndProc(HWND hWnd, UINT wMsg, WPARAM wParam, LPARAM lParam)
                    BOOL bDir;
                    BOOL bChangeDisplay = FALSE;
 
+                   hwndNext = NULL;
+
                    GetTreeWindows(hwndChild, &hwndTree, &hwndDir);
                   
                    // Check to see if we can change to the directory window

--- a/src/wfinfo.c
+++ b/src/wfinfo.c
@@ -1059,6 +1059,8 @@ UpdateDriveListWorker(VOID)
 
    INT iUpdatePhantom = iUpdateReal ^ 1;
 
+   hEnum = NULL;
+
 
    //
    // GetLogicalDrives simply calls GetDriveType,
@@ -1313,11 +1315,13 @@ EnumRetry:
       rgiDriveReal[iUpdatePhantom][i] = 0;
    }
 
-   if (bOpenEnumSucceed)
+   if (bOpenEnumSucceed) {
       WNetCloseEnum(hEnum);
+   }
 
-   if (pcBuf)
+   if (pcBuf) {
       LocalFree((HANDLE)pcBuf);
+   }
 
 
    PostMessage(hwndFrame, FS_UPDATEDRIVETYPECOMPLETE, (WPARAM)cRealDrives, 0L);

--- a/src/wfutil.c
+++ b/src/wfutil.c
@@ -1122,9 +1122,11 @@ SetDlgDirectory(HWND hDlg, LPTSTR pszPath)
   HWND      hDlgItem;
   HANDLE    hFont;
   HANDLE    hFontBak;
-  TCHAR      szPath[MAXPATHLEN+5];
-  TCHAR      szTemp[MAXPATHLEN+20];
-  TCHAR      szMessage[MAXMESSAGELEN];
+  TCHAR     szPath[MAXPATHLEN+5];
+  TCHAR     szTemp[MAXPATHLEN+20];
+  TCHAR     szMessage[MAXMESSAGELEN];
+
+  hFontBak = NULL;
 
   if (pszPath)
       lstrcpy(szPath, pszPath);
@@ -1143,14 +1145,16 @@ SetDlgDirectory(HWND hDlg, LPTSTR pszPath)
       // This is required because Japanese Windows uses System font
       // for dialog box
       //
-      if (hFont)
+      if (hFont) {
          hFontBak = SelectObject(hDC, hFont);
+      }
 
       GetTextExtentPoint32(hDC, szMessage, lstrlen(szMessage), &size);
       CompactPath(hDC, szPath, (rc.right-rc.left-size.cx));
 
-      if (hFont)
+      if (hFont) {
          SelectObject(hDC, hFontBak);
+      }
 
       ReleaseDC(hDlg, hDC);
       wsprintf(szTemp, szMessage, szPath);


### PR DESCRIPTION
As part of generating an official build, one warning was issued for not using SdlCheck (see https://learn.microsoft.com/en-us/cpp/build/reference/sdl-enable-additional-security-checks?view=msvc-170 .)  Enabling this has the effect of enabling use of uninitialized pointer local variables, and most of this change revolves around that.  The general pattern seems to be Winfile using two locals, one which is initialized if a second is set, then later consumed if the second is set.  The compiler is not smart enough to understand that whenever it is used, the local will be initialized.  The changes here have the effect of suppressing the compiler warning, although any use of the local where it hasn't been initialized with the correct value will still be incorrect.  About the best thing these changes do is force a deterministic failure rather than consume uninitialized stack and fail in random ways.

This also splits the XP build definition from the regular one, since it seems to have enough XP-specific switches now that doing so is cleaner.  SdlCheck is only enabled for the 2022 compiler, so it's not present in the XP build.