### PR TITLE
Convert relative paths to absolute in initial directory, INI file reading and goto

### DIFF
--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -601,11 +601,23 @@ LRESULT APIENTRY GotoEditSubclassProc(
 VOID
 SetCurrentPathOfWindow(LPWSTR szPath)
 {
-	HWND hwndActive = (HWND)SendMessage(hwndMDIClient, WM_MDIGETACTIVE, 0, 0L);
+	TCHAR szFullPath[MAXPATHLEN];
+	LPTSTR szFilePart;
+	DWORD result;
+	HWND hwndActive;
+	HWND hwndNew;
+	HWND hwndTree;
 
-	HWND hwndNew = CreateDirWindow(szPath, TRUE, hwndActive);
+	result = GetFullPathName(szPath, COUNTOF(szFullPath), szFullPath, &szFilePart);
+	if (result == 0 || result >= COUNTOF(szFullPath) || ISUNCPATH(szFullPath))
+	{
+		return;
+	}
 
-	HWND hwndTree = HasTreeWindow(hwndNew);
+	hwndActive = (HWND)SendMessage(hwndMDIClient, WM_MDIGETACTIVE, 0, 0L);
+	hwndNew = CreateDirWindow(szFullPath, TRUE, hwndActive);
+	hwndTree = HasTreeWindow(hwndNew);
+
 	if (hwndTree)
 	{
 		SetFocus(hwndTree);


### PR DESCRIPTION
Specifying a relative path on the command line when opening winfile causes it to crash (which is quite embarassing.)

Unsurprisingly, many pieces of code assume they're dealing with a fully specified path.  Winfile takes the first char and uses it to index into drive arrays.  If the first char is not a drive letter, it can end up referencing memory that is not within its drive array.

Looking around, I saw three similar places, although there may be more:

1. The new code to open a directory specified on the command line passed the user's string verbatim when opening a window, causing '.' to be treated as a drive letter.
2. The INI reading code called `CheckDirExists` which takes the first char and calculates a mod of 32 to determine the drive letter.  Characters like '.' become 'N' which is within the array.  However, the array is still only 26 elements long, so it's still possible to access elements beyond the array.  If the calculated drive did exist, the original string is used later as the drive letter, causing the same crash.
3. The goto code was similar to specifying on the command line, where entering a relative path would crash.

This change uses `GetFullPathName` in each of these cases to ensure the relative string is reasoned about as a full path.  This avoids the crashes, although specifying '..' in Goto is still not a meaningful operation because the '..' is interpreted relative to the process current directory, which is not guaranteed to be the same as the directory of the open window.