### PR TITLE
Have a hidden option for goto to cache hidden and system subtrees

### DIFF
--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -354,7 +354,7 @@ BOOL BuildDirectoryBagOValues(BagOValues<PDNODE> *pbov, vector<PDNODE> *pNodes, 
 		}
 
 		// for all directories at this level, insert into BagOValues
-        // do not insert the directories '.' or '..'; or insert empty directory names (cf. issue #194)
+		// do not insert the directories '.' or '..'; or insert empty directory names (cf. issue #194)
 
 		if ((lfndta.fd.dwFileAttributes & ATTR_DIR) == 0 || ISDOTDIR(lfndta.fd.cFileName) || lfndta.fd.cFileName[0] == CHAR_NULL)
 		{

--- a/src/wfgoto.cpp
+++ b/src/wfgoto.cpp
@@ -299,6 +299,8 @@ BOOL BuildDirectoryBagOValues(BagOValues<PDNODE> *pbov, vector<PDNODE> *pNodes, 
 	LFNDTA lfndta;
 	WCHAR szPath[MAXPATHLEN];
 	LPWSTR szEndPath;
+	BOOL bFound;
+	DWORD dwAttr;
 
 	lstrcpy(szPath, szRoot);
 	if (lstrlen(szPath) + 1 >= COUNTOF(szPath))
@@ -334,7 +336,13 @@ BOOL BuildDirectoryBagOValues(BagOValues<PDNODE> *pbov, vector<PDNODE> *pNodes, 
 	// add *.* to end of path
 	lstrcat(szPath, szStarDotStar);
 
-	BOOL bFound = WFFindFirst(&lfndta, szPath, ATTR_DIR);
+	dwAttr = ATTR_DIR;
+	if (bIndexHiddenSystem)
+	{
+		dwAttr = dwAttr | ATTR_HS;
+	}
+
+	bFound = WFFindFirst(&lfndta, szPath, dwAttr);
 
 	while (bFound)
 	{

--- a/src/wfinit.c
+++ b/src/wfinit.c
@@ -218,6 +218,7 @@ GetSettings()
    /* Get the flags out of the INI file. */
    bMinOnRun            = GetPrivateProfileInt(szSettings, szMinOnRun,            bMinOnRun,            szTheINIFile);
    bIndexOnLaunch       = GetPrivateProfileInt(szSettings, szIndexOnLaunch,       bIndexOnLaunch,       szTheINIFile);
+   bIndexHiddenSystem   = GetPrivateProfileInt(szSettings, szIndexHiddenSystem,   bIndexHiddenSystem,   szTheINIFile);
    wTextAttribs         = (WORD)GetPrivateProfileInt(szSettings, szLowerCase,     wTextAttribs,         szTheINIFile);
    bStatusBar           = GetPrivateProfileInt(szSettings, szStatusBar,           bStatusBar,           szTheINIFile);
    bDisableVisualStyles = GetPrivateProfileInt(szSettings, szDisableVisualStyles, bDisableVisualStyles, szTheINIFile);

--- a/src/winfile.h
+++ b/src/winfile.h
@@ -1213,6 +1213,7 @@ JAPANEND
 
 Extern BOOL bMinOnRun            EQ( FALSE );
 Extern BOOL bIndexOnLaunch       EQ( TRUE );
+Extern BOOL bIndexHiddenSystem   EQ( FALSE );
 Extern BOOL bStatusBar           EQ( TRUE );
 
 Extern BOOL bDriveBar            EQ( TRUE );
@@ -1260,6 +1261,7 @@ Extern TCHAR        szPunctuation[MAXPATHLEN];
 
 Extern TCHAR        szMinOnRun[]            EQ( TEXT("MinOnRun") );
 Extern TCHAR        szIndexOnLaunch[]       EQ( TEXT("IndexOnLaunch") );
+Extern TCHAR        szIndexHiddenSystem[]   EQ( TEXT("IndexHiddenSystem") );
 Extern TCHAR        szStatusBar[]           EQ( TEXT("StatusBar") );
 Extern TCHAR        szSaveSettings[]        EQ( TEXT("Save Settings") );
 Extern TCHAR        szScrollOnExpand[]      EQ( TEXT("ScrollOnExpand"));


### PR DESCRIPTION
This is to address the original issue in #100 .  In the previous code (and after this, still default code), hidden and system directories are not enumerated.  This means any subdirectories under a hidden/system directory will not be cached.

This PR adds a UI-less `winfile.ini` option to include hidden and system directories, including their children.